### PR TITLE
Progress Bars Feature.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -513,6 +513,8 @@ function Bookends:paintTo(bb, x, y)
             cfg.v_nudge = (pos_settings.line_v_nudge and pos_settings.line_v_nudge[i]) or 0
             cfg.h_nudge = (pos_settings.line_h_nudge and pos_settings.line_h_nudge[i]) or 0
             cfg.uppercase = (pos_settings.line_uppercase and pos_settings.line_uppercase[i]) or false
+            cfg.bar_height = (pos_settings.line_bar_height and pos_settings.line_bar_height[i]) or nil
+            cfg.bar_manual_width = (pos_settings.line_bar_manual_width and pos_settings.line_bar_manual_width[i]) or nil
             table.insert(line_configs, cfg)
         end
 
@@ -521,9 +523,13 @@ function Bookends:paintTo(bb, x, y)
             if p.key == key then pos_def = p; break end
         end
 
-        -- Build without truncation to measure natural width
-        local widget, w, h = OverlayWidget.buildTextWidget(text, line_configs, pos_def.h_anchor, nil)
-        pre_built[key] = { widget = widget, w = w, h = h, line_configs = line_configs, pos_def = pos_def }
+        -- Measure text-only width for overlap limits (bars excluded), then build widget
+        local _, h_margin = self:getMargin(key)
+        local h_off = self:getPositionSetting(key, "h_offset") + h_margin
+        local full_available_w = screen_w - 2 * h_off
+        local text_w = OverlayWidget.measureTextWidth(text, line_configs)
+        local widget, w, h = OverlayWidget.buildTextWidget(text, line_configs, pos_def.h_anchor, nil, nil, full_available_w)
+        pre_built[key] = { widget = widget, w = w, h = h, text_w = text_w, full_available_w = full_available_w, line_configs = line_configs, pos_def = pos_def }
     end
 
     -- Phase 3: Calculate overlap limits per row
@@ -539,9 +545,9 @@ function Bookends:paintTo(bb, x, y)
         local center_key = row == "top" and "tc" or "bc"
         local right_key = row == "top" and "tr" or "br"
 
-        local left_w = pre_built[left_key] and pre_built[left_key].w or nil
-        local center_w = pre_built[center_key] and pre_built[center_key].w or nil
-        local right_w = pre_built[right_key] and pre_built[right_key].w or nil
+        local left_w = pre_built[left_key] and pre_built[left_key].text_w or nil
+        local center_w = pre_built[center_key] and pre_built[center_key].text_w or nil
+        local right_w = pre_built[right_key] and pre_built[right_key].text_w or nil
 
         local _, left_h_margin = self:getMargin(left_key)
         local _, right_h_margin = self:getMargin(right_key)
@@ -570,7 +576,8 @@ function Bookends:paintTo(bb, x, y)
                     -- Truncation needed: free pre-built widget and rebuild with limit
                     if pb.widget and pb.widget.free then pb.widget:free() end
                     widget, w, h = OverlayWidget.buildTextWidget(
-                        expanded[key], pb.line_configs, pb.pos_def.h_anchor, max_width)
+                        expanded[key], pb.line_configs, pb.pos_def.h_anchor, max_width,
+                        nil, pb.full_available_w or screen_w)
                 else
                     -- No truncation: reuse pre-built widget
                     widget, w, h = pb.widget, pb.w, pb.h
@@ -1035,6 +1042,8 @@ function Bookends:editLineString(pos, line_idx)
     pos_settings.line_h_nudge = pos_settings.line_h_nudge or {}
     pos_settings.line_uppercase = pos_settings.line_uppercase or {}
     pos_settings.line_page_filter = pos_settings.line_page_filter or {}
+    pos_settings.line_bar_height = pos_settings.line_bar_height or {}
+    pos_settings.line_bar_manual_width = pos_settings.line_bar_manual_width or {}
 
     -- Snapshot for cancel/restore
     local original_settings = util.tableDeepCopy(pos_settings)
@@ -1046,6 +1055,8 @@ function Bookends:editLineString(pos, line_idx)
     local line_h_nudge = pos_settings.line_h_nudge[line_idx] or 0
     local line_uppercase = pos_settings.line_uppercase[line_idx] or false
     local line_page_filter = pos_settings.line_page_filter[line_idx] -- nil = all pages
+    local line_bar_height = pos_settings.line_bar_height[line_idx]       -- nil = auto
+    local line_bar_manual_width = pos_settings.line_bar_manual_width[line_idx] or 0
 
     -- Live preview: write current local state to settings and repaint
     local function applyLivePreview()
@@ -1056,6 +1067,8 @@ function Bookends:editLineString(pos, line_idx)
         pos_settings.line_h_nudge[line_idx] = line_h_nudge ~= 0 and line_h_nudge or nil
         pos_settings.line_uppercase[line_idx] = line_uppercase or nil
         pos_settings.line_page_filter[line_idx] = line_page_filter
+        pos_settings.line_bar_height[line_idx] = line_bar_height
+        pos_settings.line_bar_manual_width[line_idx] = line_bar_manual_width ~= 0 and line_bar_manual_width or nil
         self:markDirty()
     end
 
@@ -1098,6 +1111,22 @@ function Bookends:editLineString(pos, line_idx)
             if line_page_filter == "odd" then return _("Odd pg")
             elseif line_page_filter == "even" then return _("Even pg")
             else return _("All pg") end
+        end,
+        callback = function() end,
+    }
+    local bar_h_button = {
+        text_func = function()
+            return _("Bar h") .. ": " .. (line_bar_height or "auto")
+        end,
+        callback = function() end,
+    }
+    local bar_mw_button = {
+        text_func = function()
+            if line_bar_manual_width and line_bar_manual_width > 0 then
+                return _("Bar w") .. ": " .. line_bar_manual_width .. "px"
+            else
+                return _("Bar w: full")
+            end
         end,
         callback = function() end,
     }
@@ -1158,6 +1187,39 @@ function Bookends:editLineString(pos, line_idx)
             applyLivePreview()
             format_dialog:reinit()
         end)
+    end
+
+    bar_h_button.callback = function()
+        local cur = line_bar_height or 16
+        UIManager:show(SpinWidget:new{
+            value         = cur,
+            value_min     = 4,
+            value_max     = 60,
+            default_value = 16,
+            title_text    = _("Bar height (px) for line") .. " " .. line_idx,
+            ok_text       = _("Set"),
+            callback      = function(spin)
+                line_bar_height = spin.value
+                applyLivePreview()
+                format_dialog:reinit()
+            end,
+        })
+    end
+
+    bar_mw_button.callback = function()
+        UIManager:show(SpinWidget:new{
+            value         = line_bar_manual_width or 0,
+            value_min     = 0,
+            value_max     = Screen:getWidth(),
+            default_value = 0,
+            title_text    = _("Bar width (px, 0 = full)"),
+            ok_text       = _("Set"),
+            callback      = function(spin)
+                line_bar_manual_width = spin.value
+                applyLivePreview()
+                format_dialog:reinit()
+            end,
+        })
     end
 
     -- Nudge buttons (1px per tap)
@@ -1235,7 +1297,9 @@ function Bookends:editLineString(pos, line_idx)
         buttons = {
             -- Row 1: style controls
             { style_button, size_button, font_button, case_button, page_filter_button },
-            -- Row 2: position nudge (L/R on left, label center, U/D on right)
+            -- Row 2: bar dimension controls
+            { bar_h_button, bar_mw_button },
+            -- Row 3: position nudge (L/R on left, label center, U/D on right)
             { nudge_left, nudge_right, nudge_label, nudge_up, nudge_down },
             -- Row 3: main actions
             {
@@ -1282,6 +1346,8 @@ function Bookends:editLineString(pos, line_idx)
                             sparseRemove(pos_settings.line_h_nudge, line_idx)
                             sparseRemove(pos_settings.line_uppercase, line_idx)
                             sparseRemove(pos_settings.line_page_filter, line_idx)
+                            sparseRemove(pos_settings.line_bar_height, line_idx)
+                            sparseRemove(pos_settings.line_bar_manual_width, line_idx)
                         else
                             -- Save the text (style/font/nudge already applied via live preview)
                             pos_settings.lines[line_idx] = new_text
@@ -1321,6 +1387,8 @@ function Bookends:showLineManageDialog(pos, line_idx, touchmenu_instance)
         sparseRemove(ps.line_h_nudge, line_idx)
         sparseRemove(ps.line_uppercase, line_idx)
         sparseRemove(ps.line_page_filter, line_idx)
+        sparseRemove(ps.line_bar_height, line_idx)
+        sparseRemove(ps.line_bar_manual_width, line_idx)
         self:savePositionSetting(pos.key)
         self:markDirty()
         refreshMenu()
@@ -1348,6 +1416,12 @@ function Bookends:showLineManageDialog(pos, line_idx, touchmenu_instance)
         end
         if ps.line_page_filter then
             ps.line_page_filter[a], ps.line_page_filter[b] = ps.line_page_filter[b], ps.line_page_filter[a]
+        end
+        if ps.line_bar_height then
+            ps.line_bar_height[a], ps.line_bar_height[b] = ps.line_bar_height[b], ps.line_bar_height[a]
+        end
+        if ps.line_bar_manual_width then
+            ps.line_bar_manual_width[a], ps.line_bar_manual_width[b] = ps.line_bar_manual_width[b], ps.line_bar_manual_width[a]
         end
         self:savePositionSetting(pos.key)
         self:markDirty()
@@ -1493,6 +1567,8 @@ Bookends.TOKEN_CATALOG = {
         { "%G", _("Total pages in chapter") },
         { "%l", _("Pages left in chapter") },
         { "%L", _("Pages left in book") },
+        { "%bar_book",     _("Book progress bar") },
+        { "%bar_chapter",  _("Chapter progress bar") },
     }},
     { _("Time / Date"), {
         { "%k", _("12-hour clock") },

--- a/overlay_widget.lua
+++ b/overlay_widget.lua
@@ -2,6 +2,7 @@ local Font = require("ui/font")
 local TextWidget = require("ui/widget/textwidget")
 local Device = require("device")
 local Screen = Device.screen
+local Tokens = require("tokens")
 
 local OverlayWidget = {}
 
@@ -49,86 +50,271 @@ function MultiLineWidget:free()
     self.lines = {}
 end
 
---- Build a TextWidget or MultiLineWidget for a single line or multi-line string.
--- @param text string: the expanded text (may contain newlines)
--- @param line_configs table: array of {face=, bold=} per line
--- @param h_anchor string: "left", "center", or "right"
--- @param max_width number or nil: if set, truncate lines to this pixel width
--- @return widget, width, height
-function OverlayWidget.buildTextWidget(text, line_configs, h_anchor, max_width)
-    if max_width and max_width <= 0 then
-        return nil, 0, 0
+-- ─── BarWidget ─────────────────────────────────────────────────────────────
+-- Rounded-bordered progress bar with a dark-gray fill and optional tick marks.
+
+local BarWidget = {}
+BarWidget.__index = BarWidget
+
+function BarWidget:new(o)
+    return setmetatable(o or {}, self)
+end
+
+function BarWidget:paintTo(bb, x, y)
+    local w          = self.width
+    local h          = self.height
+    local fraction   = math.max(0, math.min(1, self.fraction or 0))
+    local ticks      = self.ticks or {}
+    local Blitbuffer = require("ffi/blitbuffer")
+
+    local border  = 2
+    local radius  = 2
+    local padding = 4
+
+    bb:paintRoundedRect(x, y, w, h, Blitbuffer.COLOR_WHITE, radius)
+    bb:paintBorder(x, y, w, h, border, Blitbuffer.COLOR_BLACK, radius)
+
+    local inset   = border + padding
+    local inner_w = w - 2 * inset
+    local inner_h = h - 2 * inset
+    local fill_w  = math.max(0, math.ceil(inner_w * fraction))
+    if fill_w > 0 and inner_h > 0 then
+        bb:paintRect(x + inset, y + inset, fill_w, inner_h, Blitbuffer.COLOR_DARK_GRAY)
     end
+
+    local tick_inset   = 1
+    local tick_inner_w = w - 2 * tick_inset
+    local tix          = x + tick_inset
+    local tiy          = y + tick_inset
+    for _, frac in ipairs(ticks) do
+        if frac > 0 and frac < 1 then
+            local tx = tix + math.floor(tick_inner_w * frac)
+            tx = math.max(tix, math.min(tx, tix + tick_inner_w - 1))
+            bb:paintRect(tx, tiy, 1, h - 2 * tick_inset, Blitbuffer.COLOR_BLACK)
+        end
+    end
+end
+
+function BarWidget:getSize()
+    return { w = self.width, h = self.height }
+end
+
+function BarWidget:free() end
+
+-- ─── HorizontalRowWidget ───────────────────────────────────────────────────
+-- Paints text and bar segments left-to-right, vertically centred in the row.
+
+local HorizontalRowWidget = {}
+HorizontalRowWidget.__index = HorizontalRowWidget
+
+function HorizontalRowWidget:new(o)
+    return setmetatable(o or {}, self)
+end
+
+function HorizontalRowWidget:paintTo(bb, x, y)
+    local row_h    = self.height
+    local x_cursor = x
+    for _, seg in ipairs(self.segments) do
+        local seg_y = y + math.floor((row_h - seg.h) / 2)
+        seg.widget:paintTo(bb, x_cursor, seg_y)
+        x_cursor = x_cursor + seg.w
+    end
+end
+
+function HorizontalRowWidget:getSize()
+    return { w = self.width, h = self.height }
+end
+
+function HorizontalRowWidget:free()
+    for _, seg in ipairs(self.segments) do
+        if seg.widget and seg.widget.free then seg.widget:free() end
+    end
+    self.segments = {}
+end
+
+-- ─── Internal helpers ─────────────────────────────────────────────────────
+
+local function buildBarWidget(info, bar_w, bar_h)
+    bar_h = math.max(bar_h or 16, 16)
+    bar_w = math.max(4, bar_w or Screen:getWidth())
+    return BarWidget:new{
+        width    = bar_w,
+        height   = bar_h,
+        fraction = info.pct or 0,
+        ticks    = info.ticks or {},
+    }
+end
+
+-- Build a HorizontalRowWidget from text/bar segments.
+-- full_w: uncapped slot width used for auto bar sizing.
+-- max_width: text truncation limit (nil = none).
+local function buildHorizontalRow(segments, cfg, full_w, max_width)
+    local bar_h     = cfg.bar_height or math.max(cfg.face and cfg.face.size or 16, 16)
+    local fixed_bar_w = (cfg.bar_manual_width and cfg.bar_manual_width > 0) and cfg.bar_manual_width or nil
+    local built    = {}
+    local used_w   = 0
+    local auto_bars = 0
+
+    for _, seg in ipairs(segments) do
+        if seg.kind == "text" and seg.text ~= "" then
+            local tw = TextWidget:new(textWidgetOpts{
+                text                   = seg.text,
+                face                   = cfg.face,
+                bold                   = cfg.bold,
+                max_width              = max_width,
+                truncate_with_ellipsis = max_width ~= nil,
+            })
+            local sz = tw:getSize()
+            table.insert(built, { widget = tw, w = sz.w, h = sz.h })
+            used_w = used_w + sz.w
+        elseif seg.kind == "bar" then
+            if fixed_bar_w then
+                local bar = buildBarWidget(seg.info, fixed_bar_w, bar_h)
+                table.insert(built, { widget = bar, w = fixed_bar_w, h = bar_h })
+                used_w = used_w + fixed_bar_w
+            else
+                table.insert(built, { _bar_auto = true, info = seg.info, w = 0, h = bar_h })
+                auto_bars = auto_bars + 1
+            end
+        end
+    end
+
+    if auto_bars > 0 then
+        local each = math.max(4, math.floor(
+            math.max(0, (full_w or Screen:getWidth()) - used_w) / auto_bars))
+        for _, entry in ipairs(built) do
+            if entry._bar_auto then
+                entry.widget    = buildBarWidget(entry.info, each, bar_h)
+                entry.w         = each
+                entry._bar_auto = nil
+            end
+        end
+    end
+
+    local total_w = 0
+    local row_h   = 0
+    for _, entry in ipairs(built) do
+        total_w = total_w + entry.w
+        if entry.h > row_h then row_h = entry.h end
+    end
+
+    if #built == 0 then return nil, 0, 0 end
+    return HorizontalRowWidget:new{ segments = built, width = total_w, height = row_h },
+           total_w, row_h
+end
+
+--- Build a widget for a possibly multi-line, possibly bar-containing string.
+-- @param text          expanded string (may contain bar sentinels)
+-- @param line_configs  per-line configs with face, bold, v_nudge, h_nudge, uppercase
+-- @param h_anchor      "left"|"center"|"right"
+-- @param max_width     number|nil  text truncation cap
+-- @param _available_w  (unused, accepted for API compatibility)
+-- @param full_w        number|nil  uncapped slot width for auto bar sizing
+-- @return widget, width, height
+function OverlayWidget.buildTextWidget(text, line_configs, h_anchor, max_width, _available_w, full_w)
+    full_w = full_w or Screen:getWidth()
+    if max_width and max_width <= 0 then return nil, 0, 0 end
 
     local lines = {}
     for line in text:gmatch("([^\n]+)") do
         table.insert(lines, line)
     end
-    if #lines == 0 then
-        return nil, 0, 0
-    end
+    if #lines == 0 then return nil, 0, 0 end
 
-    -- Get config for line i (fall back to last config if fewer configs than lines)
     local function getConfig(i)
-        return line_configs[i] or line_configs[#line_configs] or { face = nil, bold = false }
+        return line_configs[i] or line_configs[#line_configs]
+               or { face = nil, bold = false }
     end
 
-    if #lines == 1 then
-        local cfg = getConfig(1)
+    local align = "center"
+    if h_anchor == "left"  then align = "left"  end
+    if h_anchor == "right" then align = "right" end
+
+    -- Fast path: single plain text line
+    if #lines == 1 and not Tokens.lineHasBar(lines[1]) then
+        local cfg         = getConfig(1)
         local display_text = cfg.uppercase and lines[1]:upper() or lines[1]
         local tw = TextWidget:new(textWidgetOpts{
-            text = display_text,
-            face = cfg.face,
-            bold = cfg.bold,
-            max_width = max_width,
+            text                   = display_text,
+            face                   = cfg.face,
+            bold                   = cfg.bold,
+            max_width              = max_width,
             truncate_with_ellipsis = max_width ~= nil,
         })
         local size = tw:getSize()
         return tw, size.w, size.h
     end
 
-    local align = "center"
-    if h_anchor == "left" then
-        align = "left"
-    elseif h_anchor == "right" then
-        align = "right"
+    -- Fast path: single bar-containing line
+    if #lines == 1 then
+        local cfg = getConfig(1)
+        local row, rw, rh = buildHorizontalRow(
+            Tokens.splitLineSegments(lines[1]), cfg, full_w, max_width)
+        return row, rw, rh
     end
 
+    -- Multi-line
     local line_entries = {}
-    local max_w = 0
-    local total_h = 0
+    local max_w        = 0
+    local total_h      = 0
     for i, line in ipairs(lines) do
         local cfg = getConfig(i)
-        local display_text = cfg.uppercase and line:upper() or line
-        local tw = TextWidget:new(textWidgetOpts{
-            text = display_text,
-            face = cfg.face,
-            bold = cfg.bold,
-            max_width = max_width,
-            truncate_with_ellipsis = max_width ~= nil,
-        })
-        local size = tw:getSize()
-        table.insert(line_entries, {
-            widget = tw, w = size.w, h = size.h,
-            v_nudge = cfg.v_nudge or 0, h_nudge = cfg.h_nudge or 0,
-        })
-        if size.w > max_w then max_w = size.w end
-        total_h = total_h + size.h
+        if Tokens.lineHasBar(line) then
+            local row, rw, rh = buildHorizontalRow(
+                Tokens.splitLineSegments(line), cfg, full_w, max_width)
+            if row then
+                table.insert(line_entries, {
+                    widget  = row, w = rw, h = rh,
+                    v_nudge = cfg.v_nudge or 0, h_nudge = cfg.h_nudge or 0,
+                })
+                if rw > max_w then max_w = rw end
+                total_h = total_h + rh
+            end
+        else
+            local display_text = cfg.uppercase and line:upper() or line
+            local tw = TextWidget:new(textWidgetOpts{
+                text                   = display_text,
+                face                   = cfg.face,
+                bold                   = cfg.bold,
+                max_width              = max_width,
+                truncate_with_ellipsis = max_width ~= nil,
+            })
+            local sz = tw:getSize()
+            table.insert(line_entries, {
+                widget  = tw, w = sz.w, h = sz.h,
+                v_nudge = cfg.v_nudge or 0, h_nudge = cfg.h_nudge or 0,
+            })
+            if sz.w > max_w then max_w = sz.w end
+            total_h = total_h + sz.h
+        end
     end
 
-    local mlw = MultiLineWidget:new{
-        lines = line_entries,
-        width = max_w,
-        height = total_h,
-        align = align,
-    }
-    return mlw, max_w, total_h
+    if #line_entries == 0 then return nil, 0, 0 end
+    local reported_w = math.max(max_w, 4)
+    return MultiLineWidget:new{
+        lines = line_entries, width = reported_w, height = total_h, align = align,
+    }, reported_w, total_h
 end
 
---- Build a widget with no truncation (for measurement), returning it for potential reuse.
--- @return widget, width, height
-function OverlayWidget.buildAndMeasure(text, line_configs, h_anchor)
-    return OverlayWidget.buildTextWidget(text, line_configs, h_anchor, nil)
+--- Measure only the text-portion pixel width (bar lines excluded).
+-- Used for overlap-prevention so bars don't inflate the available limits.
+function OverlayWidget.measureTextWidth(text, line_configs)
+    local max_w = 0
+    local i     = 0
+    for line in text:gmatch("([^\n]+)") do
+        i = i + 1
+        if not Tokens.lineHasBar(line) then
+            local cfg = line_configs[i] or line_configs[#line_configs]
+                        or { face = nil, bold = false }
+            local tw = TextWidget:new(textWidgetOpts{
+                text = line, face = cfg.face, bold = cfg.bold,
+            })
+            local w = tw:getSize().w
+            tw:free()
+            if w > max_w then max_w = w end
+        end
+    end
+    return max_w
 end
 
 --- Calculate max_width for each position in a row, applying overlap prevention.

--- a/tokens.lua
+++ b/tokens.lua
@@ -3,6 +3,54 @@ local datetime = require("datetime")
 
 local Tokens = {}
 
+--- Returns true if the line contains a bar sentinel string.
+function Tokens.lineHasBar(s)
+    return type(s) == "string" and
+        (s:find("BARBOOK:[0-9.]+;[0-9.,]*:END", 1) ~= nil or
+         s:find("BARCHAPTER:[0-9.]+:END", 1) ~= nil)
+end
+
+--- Decode a bar sentinel string into { kind, pct, ticks }.
+function Tokens.decodeBar(s)
+    local pct, tick_str = s:match("^BARBOOK:([0-9.]+);([0-9.,]*):END$")
+    if pct then
+        local ticks = {}
+        for t in tick_str:gmatch("[0-9.]+") do
+            local v = tonumber(t)
+            if v then table.insert(ticks, v) end
+        end
+        return { kind = "book", pct = tonumber(pct), ticks = ticks }
+    end
+    local pct2 = s:match("^BARCHAPTER:([0-9.]+):END$")
+    if pct2 then
+        return { kind = "chapter", pct = tonumber(pct2), ticks = {} }
+    end
+    return nil
+end
+
+--- Split a line into an ordered list of { kind="text"|"bar", text=...|info=... } segments.
+function Tokens.splitLineSegments(line)
+    local segments = {}
+    local remaining = line
+    while true do
+        local best_s, best_e = nil, nil
+        for _, p in ipairs({ "BARBOOK:[0-9.]+;[0-9.,]*:END", "BARCHAPTER:[0-9.]+:END" }) do
+            local s, e = remaining:find(p)
+            if s and (best_s == nil or s < best_s) then
+                best_s, best_e = s, e
+            end
+        end
+        if not best_s then
+            table.insert(segments, { kind = "text", text = remaining })
+            break
+        end
+        table.insert(segments, { kind = "text", text = remaining:sub(1, best_s - 1) })
+        table.insert(segments, { kind = "bar",  info = Tokens.decodeBar(remaining:sub(best_s, best_e)) })
+        remaining = remaining:sub(best_e + 1)
+    end
+    return segments
+end
+
 function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, preview_mode)
     -- Fast path: no tokens
     if not format_str:find("%%") then
@@ -30,7 +78,9 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
             ["%m"] = "[mem]", ["%M"] = "[rss]",
             ["%v"] = "[disk]",
         }
-        return format_str:gsub("(%%%a)", preview)
+        local r = format_str:gsub("%%bar_chapter", "[ch. bar]")
+        r = r:gsub("%%bar_book", "[book bar]")
+        return r:gsub("(%%%a)", preview)
     end
 
     -- Helper: check if any of the given tokens appear in the format string
@@ -77,17 +127,19 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
 
     -- Chapter progress
     local chapter_pct = ""
+    local chapter_pct_raw = 0
     local chapter_pages_done = ""
     local chapter_pages_left = ""
     local chapter_total_pages = ""
     local chapter_title = ""
-    if needs("P", "g", "G", "l", "C") and pageno and ui.toc then
+    if needs("P", "g", "G", "l", "C", "bar_chapter") and pageno and ui.toc then
         local done = ui.toc:getChapterPagesDone(pageno)
         local total = ui.toc:getChapterPageCount(pageno)
         if done and total and total > 0 then
             chapter_pages_done = done + 1
             chapter_total_pages = total
             chapter_pct = math.floor(chapter_pages_done / total * 100) .. "%"
+            chapter_pct_raw = math.max(0, math.min(1, chapter_pages_done / total))
         end
         local left = ui.toc:getChapterPagesLeft(pageno)
         if left then chapter_pages_left = left end
@@ -310,6 +362,34 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
         end
     end
 
+    -- Book progress fraction and chapter tick marks for %bar_book
+    local book_pct_raw = 0
+    local chapter_ticks = {}
+    if needs("bar_book") and pageno then
+        local raw_total = doc:getPageCount()
+        if raw_total and raw_total > 0 then
+            book_pct_raw = math.max(0, math.min(1, pageno / raw_total))
+            if ui.toc then
+                local ok, ticks = pcall(function() return ui.toc:getTocTicksFlattened() end)
+                if ok and ticks then
+                    if doc:hasHiddenFlows() then
+                        local flow = doc:getPageFlow(pageno)
+                        local flow_total = doc:getTotalPagesInFlow(flow)
+                        for _, page in ipairs(ticks) do
+                            if doc:getPageFlow(page) == flow and flow_total > 0 then
+                                table.insert(chapter_ticks, doc:getPageNumberInFlow(page) / flow_total)
+                            end
+                        end
+                    else
+                        for _, page in ipairs(ticks) do
+                            table.insert(chapter_ticks, page / raw_total)
+                        end
+                    end
+                end
+            end
+        end
+    end
+
     local replace = {
         -- Page/Progress
         ["%c"] = tostring(currentpage),
@@ -356,10 +436,19 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
         ["%M"] = ram_mb,
         ["%v"] = disk_avail,
     }
+    -- Bar tokens MUST be replaced before single-char substitution (avoids %b being consumed)
+    local result = format_str
+    if format_str:find("%%bar_") then
+        local tick_str = table.concat(chapter_ticks, ",")
+        result = result:gsub("%%bar_chapter",
+            string.format("BARCHAPTER:%.6f:END", chapter_pct_raw))
+        result = result:gsub("%%bar_book",
+            string.format("BARBOOK:%.6f;%s:END", book_pct_raw, tick_str))
+    end
     -- Track whether all tokens in the string resolved to empty or "0"
     local has_token = false
     local all_empty = true
-    local result = format_str:gsub("(%%%a)", function(token)
+    result = result:gsub("(%%%a)", function(token)
         local val = replace[token]
         if val == nil then return token end -- unknown token, leave as-is
         has_token = true


### PR DESCRIPTION
### New feature: %bar_book and %bar_chapter progress bar tokens
Two new tokens that render graphical progress bars directly into any overlay position line.

### Usage:

- %bar_book — horizontal progress bar showing whole-book progress, with tick marks at each chapter boundary
- %bar_chapter — horizontal progress bar showing progress through the current chapter
- Bars can be mixed with text on the same line: e.g. 📖 %bar_book or %bar_chapter  %P

### Bar appearance:

- Rounded white background with a 2px black border
- Dark-gray filled progress, 1px black tick lines at chapter boundaries (book bar)

### Per-line bar dimensions (set in the line editor dialog alongside font/style/nudge controls):

- Bar h — bar height in pixels (4–60px), independent per line
- Bar w — fixed bar width in pixels; 0 means fill the available slot automatically

### Files changed:

- tokens.lua — bar sentinel encoding/decoding, lineHasBar(), splitLineSegments(), decodeBar() helpers; %bar_book/%bar_chapter token expansion with chapter tick fractions from TOC

- overlay_widget.lua — BarWidget (rounded border, fill, ticks), HorizontalRowWidget (inline text+bar layout), measureTextWidth() (excludes bar lines from overlap calculations), updated buildTextWidget to handle bar sentinels

- main.lua — line_bar_height and line_bar_manual_width per-line settings; two new buttons in the line editor dialog; settings correctly saved, restored on cancel, swapped on reorder, removed on delete, and included in presets