### PR TITLE
fix(tokens): use stable idx and count from pagemap API for page numbering

### DIFF
--- a/tokens.lua
+++ b/tokens.lua
@@ -133,8 +133,9 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
     local pages_left_book = ""
     if needs("c", "t", "p", "L") then
         if ui.pagemap and ui.pagemap:wantsPageLabels() then
-            currentpage = ui.pagemap:getCurrentPageLabel(true) or ""
-            totalpages = ui.pagemap:getLastPageLabel(true) or ""
+            local label, idx, count = ui.pagemap:getCurrentPageLabel(true)
+            currentpage = idx or pageno or 0
+            totalpages = count or doc:getPageCount()
         elseif pageno and doc:hasHiddenFlows() then
             currentpage = doc:getPageNumberInFlow(pageno)
             local flow = doc:getPageFlow(pageno)


### PR DESCRIPTION
**Problem**
EPUB with pagemap labels containing non-numeric values (roman numerals, etc.) displayed incorrectly in the footer. For a 391-page EPUB, the footer showed `Page X of IV` instead of numeric page numbers.

**Root Cause**
The `%t` (total pages) token used `getLastPageLabel(true)` which returned raw label text (e.g., "IV" from a back-matter page) instead of the numeric page count.

**Solution**
Use the stable `idx` and `count` return values from `getCurrentPageLabel(true)` instead of deriving numeric values from raw labels. The KOReader API already provides:
- `idx`: stable page index in the pagemap
- `count`: total pages in the pagemap

**Impact**
- Fixes page display in documents with mixed-label pagemaps
- No impact on documents without pagemap labels
- Minimal footprint: 3 insertions, 2 deletions