### PR TITLE
feat(bars): Add radial (pie chart) progress bar styles

### DIFF
--- a/bookends_line_editor.lua
+++ b/bookends_line_editor.lua
@@ -171,7 +171,7 @@ function LineEditor.attach(Bookends)
         local bar_style_button = {
             text_func = function()
                 if not hasBarToken() then return "" end
-                local labels = { bordered = _("Border"), solid = _("Solid"), rounded = _("Round"), metro = _("Metro"), wavy = _("Wave") }
+                local labels = { bordered = _("Border"), solid = _("Solid"), rounded = _("Round"), metro = _("Metro"), wavy = _("Wave"), radial = _("Radial"), radial_hollow = _("Hollow") }
                 return labels[line_bar_style or "bordered"] or _("Border")
             end,
             enabled_func = hasBarToken,
@@ -213,7 +213,7 @@ function LineEditor.attach(Bookends)
         bar_style_button.callback = function()
             format_dialog:onCloseKeyboard()
             local next_style = Utils.cycleNext(
-                { "bordered", "solid", "rounded", "metro", "wavy" },
+                { "bordered", "solid", "rounded", "metro", "wavy", "radial", "radial_hollow" },
                 line_bar_style or "bordered")
             line_bar_style = next_style ~= "bordered" and next_style or nil
             applyLivePreview()

--- a/bookends_overlay_widget.lua
+++ b/bookends_overlay_widget.lua
@@ -1180,12 +1180,7 @@ function OverlayWidget.paintProgressBar(bb, x, y, w, h, fraction, ticks, style, 
                     if angle < 0 then angle = angle + two_pi end
                     local pixel_frac = angle / two_pi
 
-                    local in_fill
-                    if reverse then
-                        in_fill = pixel_frac >= (1 - fraction)
-                    else
-                        in_fill = pixel_frac <= fraction
-                    end
+                    local in_fill = pixel_frac <= fraction
                     local color = in_fill and radial_fill or radial_bg
                     if color then
                         bb:paintRect(cx + px, cy + py, 1, 1, color)
@@ -1198,7 +1193,7 @@ function OverlayWidget.paintProgressBar(bb, x, y, w, h, fraction, ticks, style, 
         for _, tick in ipairs(ticks or {}) do
             local tick_frac = type(tick) == "table" and tick[1] or tick
             local tick_w = type(tick) == "table" and tick[2] or 1
-            if reverse then tick_frac = 1 - tick_frac end
+
             local tick_angle = tick_frac * two_pi - math.pi / 2  -- 0 = top (12 o'clock)
             -- Adjusted: tick at fraction 0 points up. tick_angle measured from 3 o'clock.
             -- Recalculate: from 12 o'clock clockwise
@@ -1216,12 +1211,7 @@ function OverlayWidget.paintProgressBar(bb, x, y, w, h, fraction, ticks, style, 
                 local pix_angle = math.atan2(t * cos_a, -(t * sin_a))
                 if pix_angle < 0 then pix_angle = pix_angle + two_pi end
                 local pix_frac = pix_angle / two_pi
-                local in_fill
-                if reverse then
-                    in_fill = pix_frac >= (1 - fraction)
-                else
-                    in_fill = pix_frac <= fraction
-                end
+                local in_fill = pix_frac <= fraction
                 local tick_color
                 if invert_read_ticks ~= false and in_fill then
                     tick_color = resolveColor(custom_invert, Blitbuffer.COLOR_WHITE)

--- a/bookends_overlay_widget.lua
+++ b/bookends_overlay_widget.lua
@@ -293,6 +293,10 @@ local function buildBarLine(text, cfg, available_w, max_width)
     else
         bar_w = math.max(0, effective_w - text_total_w)
     end
+    -- Radial bars are circular — clamp width to height so they stay square
+    if bar_style == "radial" or bar_style == "radial_hollow" then
+        bar_w = math.min(bar_w, bar_h)
+    end
 
     if bar_w < 1 then
         -- No room for bar
@@ -755,6 +759,10 @@ function OverlayWidget.buildStyledLine(segments, cfg, available_w, max_width)
         else
             bar_w = math.max(0, effective_w - text_total_w)
         end
+        -- Radial bars are circular — clamp width to height so they stay square
+        if bar_style == "radial" or bar_style == "radial_hollow" then
+            bar_w = math.min(bar_w, bar_h)
+        end
 
         if bar_w >= 1 then
             local bar_widget = BarWidget:new{
@@ -1135,6 +1143,125 @@ function OverlayWidget.paintProgressBar(bb, x, y, w, h, fraction, ticks, style, 
                 bb:paintRoundedRect(dot_dy, dot_cx, dot_r * 2, dot_r * 2, wave_dot, dot_r)
             else
                 bb:paintRoundedRect(dot_cx, dot_dy, dot_r * 2, dot_r * 2, wave_dot, dot_r)
+            end
+        end
+
+    elseif style == "radial" or style == "radial_hollow" then
+        -- Radial (pie-chart) style: a circle filled clockwise from 12 o'clock.
+        local diameter = math.min(vertical and h or w, vertical and w or h)
+        local radius = math.floor(diameter / 2)
+        if radius < 2 then radius = 2 end
+        -- Center the circle in the allocated rectangle
+        local cx = x + math.floor(w / 2)
+        local cy = y + math.floor(h / 2)
+
+        local radial_bg = resolveColor(custom_bg, Blitbuffer.COLOR_GRAY)
+        local radial_fill = resolveColor(custom_fill, Blitbuffer.COLOR_DARK_GRAY)
+        local radial_tick = resolveColor(custom_tick, Blitbuffer.COLOR_BLACK)
+        local radial_border_color = resolveColor(custom_border, Blitbuffer.COLOR_BLACK)
+
+        local r2 = radius * radius
+        local hollow = style == "radial_hollow"
+        local inner_radius = hollow and math.floor(radius * 0.55) or 0
+        local inner_r2 = inner_radius * inner_radius
+        local two_pi = 2 * math.pi
+
+        -- Paint the pie circle pixel by pixel.
+        -- Angle 0 = 12 o'clock (top), increasing clockwise.
+        for py = -radius, radius - 1 do
+            for px = -radius, radius - 1 do
+                -- Offset to pixel center for smoother circle
+                local dx = px + 0.5
+                local dy = py + 0.5
+                local d2 = dx * dx + dy * dy
+                if d2 <= r2 and d2 > inner_r2 then
+                    -- Compute angle from top, clockwise: atan2(dx, -dy) mapped to [0, 2π)
+                    local angle = math.atan2(dx, -dy)
+                    if angle < 0 then angle = angle + two_pi end
+                    local pixel_frac = angle / two_pi
+
+                    local in_fill
+                    if reverse then
+                        in_fill = pixel_frac >= (1 - fraction)
+                    else
+                        in_fill = pixel_frac <= fraction
+                    end
+                    local color = in_fill and radial_fill or radial_bg
+                    if color then
+                        bb:paintRect(cx + px, cy + py, 1, 1, color)
+                    end
+                end
+            end
+        end
+
+        -- Chapter tick marks: radial lines from center to edge at each chapter boundary
+        for _, tick in ipairs(ticks or {}) do
+            local tick_frac = type(tick) == "table" and tick[1] or tick
+            local tick_w = type(tick) == "table" and tick[2] or 1
+            if reverse then tick_frac = 1 - tick_frac end
+            local tick_angle = tick_frac * two_pi - math.pi / 2  -- 0 = top (12 o'clock)
+            -- Adjusted: tick at fraction 0 points up. tick_angle measured from 3 o'clock.
+            -- Recalculate: from 12 o'clock clockwise
+            tick_angle = tick_frac * two_pi
+            local cos_a = math.cos(tick_angle - math.pi / 2)
+            local sin_a = math.sin(tick_angle - math.pi / 2)
+
+            -- Draw tick as a line from 60% of radius to the edge
+            local inner_r = math.floor(radius * (1 - tick_height_pct / 100))
+            if inner_r < inner_radius then inner_r = inner_radius end
+            for t = inner_r, radius do
+                local lx = cx + math.floor(t * cos_a)
+                local ly = cy + math.floor(t * sin_a)
+                -- Determine if this tick position is in the filled region
+                local pix_angle = math.atan2(t * cos_a, -(t * sin_a))
+                if pix_angle < 0 then pix_angle = pix_angle + two_pi end
+                local pix_frac = pix_angle / two_pi
+                local in_fill
+                if reverse then
+                    in_fill = pix_frac >= (1 - fraction)
+                else
+                    in_fill = pix_frac <= fraction
+                end
+                local tick_color
+                if invert_read_ticks ~= false and in_fill then
+                    tick_color = resolveColor(custom_invert, Blitbuffer.COLOR_WHITE)
+                else
+                    tick_color = radial_tick
+                end
+                if tick_color then
+                    bb:paintRect(lx, ly, tick_w, tick_w, tick_color)
+                end
+            end
+        end
+
+        -- Optional border circle (1px ring at the outer edge)
+        if radial_border_color then
+            local border_r2_outer = radius * radius
+            local border_r2_inner = (radius - 1) * (radius - 1)
+            for py = -radius, radius - 1 do
+                for px = -radius, radius - 1 do
+                    local dx = px + 0.5
+                    local dy = py + 0.5
+                    local d2 = dx * dx + dy * dy
+                    if d2 <= border_r2_outer and d2 > border_r2_inner then
+                        bb:paintRect(cx + px, cy + py, 1, 1, radial_border_color)
+                    end
+                end
+            end
+            -- Inner border ring for hollow variant
+            if hollow then
+                local ib_r2_outer = inner_radius * inner_radius
+                local ib_r2_inner = (inner_radius - 1) * (inner_radius - 1)
+                for py = -inner_radius, inner_radius - 1 do
+                    for px = -inner_radius, inner_radius - 1 do
+                        local dx = px + 0.5
+                        local dy = py + 0.5
+                        local d2 = dx * dx + dy * dy
+                        if d2 <= ib_r2_outer and d2 > ib_r2_inner then
+                            bb:paintRect(cx + px, cy + py, 1, 1, radial_border_color)
+                        end
+                    end
+                end
             end
         end
 

--- a/main.lua
+++ b/main.lua
@@ -1090,7 +1090,8 @@ end
 local function computeBarRect(bar_cfg, x, y, screen_w, screen_h)
     local anchor = bar_cfg.v_anchor or "bottom"
     local vertical = anchor == "left" or anchor == "right"
-    local bar_thickness = bar_cfg.height or 20
+    local is_radial = (bar_cfg.style or "solid") == "radial" or bar_cfg.style == "radial_hollow"
+    local bar_thickness = bar_cfg.height or (is_radial and 60 or 20)
     if vertical then
         -- margin_left/right reinterpreted as top/bottom insets
         local bar_h = screen_h - (bar_cfg.margin_left or 0) - (bar_cfg.margin_right or 0)
@@ -1101,6 +1102,12 @@ local function computeBarRect(bar_cfg, x, y, screen_w, screen_h)
         else
             bar_x = x + screen_w - bar_thickness - (bar_cfg.margin_v or 0)
         end
+        -- Radial: shrink to a square centered along the long axis
+        if is_radial then
+            local side = math.min(bar_thickness, bar_h)
+            bar_y = bar_y + math.floor((bar_h - side) / 2)
+            bar_h = side
+        end
         return bar_x, bar_y, bar_thickness, bar_h, vertical
     else
         local bar_w = screen_w - (bar_cfg.margin_left or 0) - (bar_cfg.margin_right or 0)
@@ -1110,6 +1117,12 @@ local function computeBarRect(bar_cfg, x, y, screen_w, screen_h)
             bar_y = y + (bar_cfg.margin_v or 0)
         else
             bar_y = y + screen_h - bar_thickness - (bar_cfg.margin_v or 0)
+        end
+        -- Radial: shrink to a square centered along the long axis
+        if is_radial then
+            local side = math.min(bar_w, bar_thickness)
+            bar_x = bar_x + math.floor((bar_w - side) / 2)
+            bar_w = side
         end
         return bar_x, bar_y, bar_w, bar_thickness, vertical
     end

--- a/menu/progress_bar_menu.lua
+++ b/menu/progress_bar_menu.lua
@@ -177,6 +177,10 @@ function Bookends:buildSingleBarMenu(bar_idx, bar_cfg)
         },
         {
             text_func = function()
+                local style = bar_cfg.style or "solid"
+                if style == "radial" or style == "radial_hollow" then
+                    return _("Fill: clockwise")
+                end
                 local labels = {
                     ltr = _("Fill: left to right"),
                     rtl = _("Fill: right to left"),
@@ -187,11 +191,16 @@ function Bookends:buildSingleBarMenu(bar_idx, bar_cfg)
                 local default_dir = is_side and "ttb" or "ltr"
                 return labels[bar_cfg.direction or default_dir]
             end,
-            enabled_func = isEnabled,
+            enabled_func = function()
+                if not isEnabled() then return false end
+                local style = bar_cfg.style or "solid"
+                return style ~= "radial" and style ~= "radial_hollow"
+            end,
             keep_menu_open = true,
             callback = function(touchmenu_instance)
-                local is_side = bar_cfg.v_anchor == "left" or bar_cfg.v_anchor == "right"
                 local style = bar_cfg.style or "solid"
+                if style == "radial" or style == "radial_hollow" then return end
+                local is_side = bar_cfg.v_anchor == "left" or bar_cfg.v_anchor == "right"
                 local axis_locked = style == "metro" or style == "wavy"
                 local cycle
                 if axis_locked and is_side then

--- a/menu/progress_bar_menu.lua
+++ b/menu/progress_bar_menu.lua
@@ -138,14 +138,14 @@ function Bookends:buildSingleBarMenu(bar_idx, bar_cfg)
         },
         {
             text_func = function()
-                local style_labels = { solid = _("Solid"), bordered = _("Bordered"), rounded = _("Rounded"), metro = _("Metro"), wavy = _("Wave") }
+                local style_labels = { solid = _("Solid"), bordered = _("Bordered"), rounded = _("Rounded"), metro = _("Metro"), wavy = _("Wave"), radial = _("Radial"), radial_hollow = _("Radial hollow") }
                 return _("Style") .. ": " .. (style_labels[bar_cfg.style] or _("Solid"))
             end,
             enabled_func = isEnabled,
             keep_menu_open = true,
             callback = function(touchmenu_instance)
                 bar_cfg.style = Utils.cycleNext(
-                    { "solid", "bordered", "rounded", "metro", "wavy" },
+                    { "solid", "bordered", "rounded", "metro", "wavy", "radial", "radial_hollow" },
                     bar_cfg.style or "solid")
                 saveBar()
                 if touchmenu_instance then touchmenu_instance:updateItems() end
@@ -211,12 +211,19 @@ function Bookends:buildSingleBarMenu(bar_idx, bar_cfg)
         },
         {
             text_func = function()
-                return _("Thickness") .. ": " .. (bar_cfg.height or 20) .. "px"
+                local is_radial = (bar_cfg.style or "solid") == "radial" or bar_cfg.style == "radial_hollow"
+                local label = is_radial and _("Diameter") or _("Thickness")
+                local default = is_radial and 60 or 20
+                return label .. ": " .. (bar_cfg.height or default) .. "px"
             end,
             enabled_func = isEnabled,
             keep_menu_open = true,
             callback = function(touchmenu_instance)
-                self:showNudgeDialog(_("Bar thickness"), bar_cfg.height or 20, 1, 60, 20, "px",
+                local is_radial = (bar_cfg.style or "solid") == "radial" or bar_cfg.style == "radial_hollow"
+                local label = is_radial and _("Diameter") or _("Bar thickness")
+                local default = is_radial and 60 or 20
+                local max_val = is_radial and 200 or 60
+                self:showNudgeDialog(label, bar_cfg.height or default, 1, max_val, default, "px",
                     function(val)
                         bar_cfg.height = val
                         saveBar()


### PR DESCRIPTION
Add some new radial progress bar styles. Both filled and "hollow" (donut) style are supported.

These are useful because they fit nicely in a crowded status menu, without taking up too much space.

I added support for chapter ticks, for parity with other bar types, but I'd personally not recommend using them

<img width="1477" height="1965" alt="CleanShot 2026-04-21 at 16 52 22@2x" src="https://github.com/user-attachments/assets/58b9c72d-fa6f-4416-8ca5-9e31bbf2698b" />
