### PR TITLE
feat(conditionals): add != operator and @ref cross-references for comparing state values

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,11 @@ Show or hide content based on device state, reading progress, time, and more usi
 [if:not series]Standalone[/if]
 [if:day=Sat or day=Sun]Weekend[/if]
 [if:format=PDF]%c / %t[/if]
+[if:chapter_title_1!=@title]%C1 · [/if]
+[if:batt!=100]charging…[/if]
 ```
 
-Comparison operators: `=` (equals), `<` (less than), `>` (greater than). Boolean operators: `and`, `or`, `not`, with parens `()` for grouping. Conditionals can be nested to any depth — `[if:A][if:B]…[/if][/if]` — and compose with `[else]`.
+Comparison operators: `=` (equals), `!=` (not equals), `<` (less than), `>` (greater than). Boolean operators: `and`, `or`, `not`, with parens `()` for grouping. Conditionals can be nested to any depth — `[if:A][if:B]…[/if][/if]` — and compose with `[else]`.
 
 | Condition | Values | Description |
 |-----------|--------|-------------|
@@ -206,6 +208,8 @@ Comparison operators: `=` (equals), `<` (less than), `>` (greater than). Boolean
 | `chapter_title_3` | string | Chapter title at depth 3 (matches `%C3`) |
 
 String predicates evaluate as falsy when the string is empty, so `[if:not series]` means "book isn't in a series" and `[if:chapter_title_2]` means "we're in a sub-chapter at depth 2".
+
+The right-hand side of a comparison can reference another state value with `@`. For example, `[if:chapter_title_1!=@title]` is true when the depth-1 chapter title differs from the book title — useful for hiding duplicate headings when a book's only top-level TOC entry is the title itself. Any `@key` that doesn't exist in the state table resolves to an empty string.
 
 Conditions evaluate live — the charging icon appears the moment you plug in, the wifi icon vanishes when you disconnect. The token picker has a dedicated **If/Else conditional tokens** submenu with syntax help, examples, and a complete reference.
 

--- a/_test_conditionals.lua
+++ b/_test_conditionals.lua
@@ -323,5 +323,78 @@ test("string: combined with operators", function()
     )
 end)
 
+-- ----------------------------------------------------------------------------
+-- Cross-reference with @ref and != operator
+-- ----------------------------------------------------------------------------
+
+test("@ref: chapter_title_1 = @title when they match", function()
+    eq(P("[if:chapter_title_1=@title]SAME[/if]",
+         {chapter_title_1="My Book", title="My Book"}), "SAME")
+end)
+
+test("@ref: chapter_title_1 = @title when they differ", function()
+    eq(P("[if:chapter_title_1=@title]SAME[/if]",
+         {chapter_title_1="Part 1", title="My Book"}), "")
+end)
+
+test("@ref: not chapter_title_1 = @title (the motivating use-case)", function()
+    -- Book with parts: chapter_title_1 is "Part 1", title is "My Book" → show it
+    eq(P("[if:not chapter_title_1=@title]%C1[/if]",
+         {chapter_title_1="Part 1", title="My Book"}), "%C1")
+    -- Book without parts: chapter_title_1 IS the title → hide it
+    eq(P("[if:not chapter_title_1=@title]%C1[/if]",
+         {chapter_title_1="My Book", title="My Book"}), "")
+end)
+
+test("@ref: missing ref key treated as empty string", function()
+    eq(P("[if:title=@nonexistent]X[/if]", {title="Foo"}), "")
+    eq(P("[if:title=@nonexistent]X[/if]", {title=""}), "X")
+end)
+
+test("@ref: numeric cross-reference", function()
+    eq(P("[if:chapter=@chapters]last[/if]", {chapter=10, chapters=10}), "last")
+    eq(P("[if:chapter=@chapters]last[/if]", {chapter=5, chapters=10}), "")
+end)
+
+test("!=: basic not-equals with literal", function()
+    eq(P("[if:a!=1]X[/if]", {a=1}), "")
+    eq(P("[if:a!=1]X[/if]", {a=2}), "X")
+end)
+
+test("!=: string not-equals", function()
+    eq(P("[if:author!=Anonymous]named[/if]", {author="Ursula K. Le Guin"}), "named")
+    eq(P("[if:author!=Anonymous]named[/if]", {author="Anonymous"}), "")
+end)
+
+test("!=: with @ref", function()
+    eq(P("[if:chapter_title_1!=@title]%C1[/if]",
+         {chapter_title_1="Part 1", title="My Book"}), "%C1")
+    eq(P("[if:chapter_title_1!=@title]%C1[/if]",
+         {chapter_title_1="My Book", title="My Book"}), "")
+end)
+
+test("!=: nil key with != returns true", function()
+    eq(P("[if:missing!=hello]X[/if]", {}), "X")
+end)
+
+test("!=: numeric not-equals", function()
+    eq(P("[if:batt!=100]not full[/if]", {batt=85}), "not full")
+    eq(P("[if:batt!=100]not full[/if]", {batt=100}), "")
+end)
+
+test("@ref: works with else branch", function()
+    eq(P("[if:chapter_title_1=@title]dup[else]%C1[/if]",
+         {chapter_title_1="Part 1", title="My Book"}), "%C1")
+    eq(P("[if:chapter_title_1=@title]dup[else]%C1[/if]",
+         {chapter_title_1="My Book", title="My Book"}), "dup")
+end)
+
+test("@ref: combined with and/or operators", function()
+    eq(P("[if:chapter_title_1!=@title and series]%S · %C1[/if]",
+         {chapter_title_1="Part 1", title="My Book", series="Saga #1"}), "%S · %C1")
+    eq(P("[if:chapter_title_1!=@title and series]%S · %C1[/if]",
+         {chapter_title_1="My Book", title="My Book", series="Saga #1"}), "")
+end)
+
 io.stdout:write(string.format("%d passed, %d failed\n", pass, fail))
 os.exit(fail == 0 and 0 or 1)

--- a/bookends_tokens.lua
+++ b/bookends_tokens.lua
@@ -116,21 +116,37 @@ local function parseNumericValue(val)
 end
 
 --- Evaluate a single condition string against a state table.
--- Supports operators =, <, > for comparisons.
+-- Supports operators =, !=, <, > for comparisons.
+-- When the right-hand value starts with @, it is resolved as a state-table
+-- key reference (e.g. chapter_title_1=@title compares two state values).
 -- Without an operator, checks if the value is truthy (non-nil, non-empty, non-zero, not "off"/"no").
 local function evaluateCondition(cond_str, state)
-    -- Try operator: key=value, key<value, key>value
+    -- Try operator: key=value, key!=value, key<value, key>value
     -- Key pattern allows underscores ([%w_]+) to support names like book_pct.
-    local key, op, value = cond_str:match("^([%w_]+)([=<>])(.+)$")
+    -- Operator pattern matches =, !=, <, >.
+    local key, op, value = cond_str:match("^([%w_]+)(!=)(.+)$")
+    if not key then
+        key, op, value = cond_str:match("^([%w_]+)([=<>])(.+)$")
+    end
     if key and op and value then
         local state_val = state[key]
-        if state_val == nil then return false end
+        if state_val == nil then return op == "!=" end
+        -- Resolve @ref on the right-hand side: look up value from state table.
+        if value:sub(1, 1) == "@" then
+            local ref_key = value:sub(2)
+            value = state[ref_key]
+            if value == nil then value = "" end
+        end
         -- Try numeric comparison (supports HH:MM → minutes)
         local num_state = tonumber(state_val)
-        local num_val = parseNumericValue(value)
+        local num_val = parseNumericValue(tostring(value))
         if op == "=" then
             if num_state and num_val then return num_state == num_val end
-            return tostring(state_val) == value
+            return tostring(state_val) == tostring(value)
+        end
+        if op == "!=" then
+            if num_state and num_val then return num_state ~= num_val end
+            return tostring(state_val) ~= tostring(value)
         end
         if not num_state or not num_val then return false end
         if op == "<" then return num_state < num_val end

--- a/menu/token_picker.lua
+++ b/menu/token_picker.lua
@@ -94,6 +94,7 @@ Bookends.CONDITIONAL_CATALOG = {
         { "[if:not series]Standalone[/if]", _("Books not in a series") },
         { "[if:chapter_title_2]%C2[else]%C1[/if]", _("Sub-chapter title when present") },
         { "[if:chapters>20]Long read[/if]", _("Books with many chapters") },
+        { "%T[if:chapter_title_1!=@title] • %C1[/if]", _("Top level chapter when title differs from book title") },
     }},
     { _("Reference"), {
         { "[if:wifi=on]...[/if]", _("wifi — on / off") },
@@ -171,7 +172,8 @@ function Bookends:showTokenPicker(on_select)
             local cond_items = {
                 { text = _("[if:key=value]show when true[/if]"), dim = true, callback = dim },
                 { text = _("[if:key=value]if true[else]if false[/if]"), dim = true, callback = dim },
-                { text = _("Compare:  =  <  >     Boolean:  and  or  not  ( )"), dim = true, callback = dim },
+                { text = _("Compare:  =  !=  <  >     Boolean:  and  or  not  ( )"), dim = true, callback = dim },
+                { text = _("Use @key as value to compare two fields: chapter_title_1!=@title"), dim = true, callback = dim },
             }
             -- Append catalog items
             for _, item in ipairs(self:buildTokenItems(self.CONDITIONAL_CATALOG, on_select)) do


### PR DESCRIPTION
Add two new features to the conditional expression evaluator that enable comparing state values against each other, not just against literals.

# Problem
Books with a flat chapter structure (no parts/sections) frequently have their sole level-1 TOC entry set to the book title. When a preset renders both the title and chapter_title_1, this produces duplicate text like "My Book · My Book". There was no way to conditionally suppress the chapter heading when it matched the title.

## != (not-equals) operator
Complements the existing =, <, > comparison operators. When the LHS key is missing from the state table, != returns true (nil is not equal to anything). Works with both string and numeric comparisons.

### Examples
- `[if:batt!=100]`
- `[if:author!=Anonymous]`

## `@ref` cross-references
The right-hand side of any comparison operator (=, !=, <, >) can now reference another state-table key by prefixing it with @. Instead of comparing against a literal value, the evaluator resolves the `@key` from the state table first. Missing `@keys` resolve to an empty string.

### Examples
- `[if:chapter_title_1!=@title]`
- `[if:chapter=@chapters]`

----

The two features compose naturally to solve the motivating problem:

`[if:chapter_title_1!=@title]%C1 · [/if]%T`
  
- Books with parts: `chapter_title_1="Part 1", title="My Book" → "Part 1 · My Book"`
- Flat books: `chapter_title_1="My Book", title="My Book" → "My Book"`

# Implementation
`evaluateCondition()` now tries matching `!=` before single-char operators (two-pass regex). When a value starts with @, the remainder is looked up in the state table before any numeric coercion or string comparison.

----
| | |
|-|-|
| <img width="1264" height="1680" alt="Screenshot_20260422-005423" src="https://github.com/user-attachments/assets/c4333ca7-91d1-4e19-9449-58e11c2ee537" /> | <img width="1264" height="1680" alt="Screenshot_20260422-005442" src="https://github.com/user-attachments/assets/d2647e11-f44b-4275-bb10-4da1a985525a" /> |
| Book has unique Level 1 chapter, rendered | Book Level 1 chapter is the same as title, hidden |
