### PR TITLE
fix: pixel truncation for multi-line list tokens

### DIFF
--- a/bookends_tokens.lua
+++ b/bookends_tokens.lua
@@ -1077,11 +1077,20 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
         if (val ~= "" and val ~= "0") or always_content[token] then
             all_empty = false
         end
-        -- Wrap with markers if this occurrence has a pixel limit
+        -- Wrap with markers if this occurrence has a pixel limit.
+        -- Apply markers per-line so they don't span newlines (the
+        -- renderer splits on \n before processing markers).
         if token_limits[token] then
             token_occurrence[token] = (token_occurrence[token] or 0) + 1
             local px = token_limits[token][token_occurrence[token]]
             if px then
+                if val:find("\n") then
+                    local wrapped = {}
+                    for line in val:gmatch("([^\n]+)") do
+                        table.insert(wrapped, "\x01" .. tostring(px) .. "\x02" .. line .. "\x03")
+                    end
+                    return table.concat(wrapped, "\n")
+                end
                 -- \x01 N \x02 value \x03
                 return "\x01" .. tostring(px) .. "\x02" .. val .. "\x03"
             end


### PR DESCRIPTION
Apply pixel-width markers per-line instead of wrapping the entire newline-separated value. The renderer splits text on newlines before processing markers, so markers spanning newlines were broken and caused raw sentinel bytes to appear in the output.

Before, if you tried to do `%A{60}`, with a multi-author work, you'd get:

```
60Author 1
Author 2
```

Now both are truncated appropriately