### PR TITLE
fix(tokens): clear stale deeper-chapter titles when ancestor closes (#50)

### DIFF
--- a/bookends_tokens.lua
+++ b/bookends_tokens.lua
@@ -601,24 +601,36 @@ function Tokens.getChapterTitlesByDepth(ui, pageno)
 
     out.chapter_count = #full_toc
     local idx = 0
-    local deepest_depth = 0
-    local deepest_title = ""
+    local max_depth_seen = 0
     for i, entry in ipairs(full_toc) do
         if entry.page and entry.page <= pageno then
             idx = i
             if entry.depth then
-                local raw = entry.title or ""
-                out.chapter_titles_by_depth[entry.depth] = raw
-                if entry.depth >= deepest_depth then
-                    deepest_depth = entry.depth
-                    deepest_title = raw
+                local d = entry.depth
+                -- A depth-d entry implicitly closes any siblings/descendants
+                -- at depth >= d, so clear them before pushing this one.
+                for dd = d, max_depth_seen do
+                    out.chapter_titles_by_depth[dd] = nil
                 end
+                out.chapter_titles_by_depth[d] = entry.title or ""
+                if d > max_depth_seen then max_depth_seen = d end
             end
         else
             break
         end
     end
     if idx > 0 then out.chapter_num = idx end
+
+    local deepest_depth = 0
+    local deepest_title = ""
+    for d = max_depth_seen, 1, -1 do
+        local t = out.chapter_titles_by_depth[d]
+        if t and t ~= "" then
+            deepest_depth = d
+            deepest_title = t
+            break
+        end
+    end
 
     if deepest_title and deepest_title ~= "" then
         out.chapter_title = deepest_title

--- a/tests/_test_tokens.lua
+++ b/tests/_test_tokens.lua
@@ -1529,6 +1529,45 @@ test("getChapterTitlesByDepth: chapter_title_num empty / _name = raw when not st
        "name falls back to raw title so layouts using only _name still work")
 end)
 
+test("getChapterTitlesByDepth: deeper middle section doesn't pin deepest forever", function()
+    -- Issue #50: a few chapters in the middle are nested one level deeper than
+    -- those before/after. Once the reader passes the last deep entry, the
+    -- deepest-title resolver must drop back to the shallower current ancestor
+    -- rather than keep showing the last deep title for the rest of the book.
+    local toc = {
+        { title = "Teil I",                   depth = 1, page = 1   },
+        { title = "Teil II",                  depth = 1, page = 50  },
+        { title = "- 103 - Nachspiel",        depth = 2, page = 80  },
+        { title = "Teil III",                 depth = 1, page = 120 },
+        { title = "Die Verlorenen",           depth = 2, page = 125 },
+    }
+    local stub_ui = {
+        toc = {
+            toc = toc,
+            getTocTitleByPage = function(_, _) return "" end,
+        },
+    }
+
+    -- Mid-Nachspiel: deepest is the depth-2 entry.
+    local mid = Tokens.getChapterTitlesByDepth(stub_ui, 100)
+    eq(mid.chapter_title, "- 103 - Nachspiel", "deepest while inside Nachspiel")
+    eq(mid.chapter_titles_by_depth[2], "- 103 - Nachspiel")
+
+    -- After Teil III opens but before Die Verlorenen: depth-2 must clear.
+    local after_part = Tokens.getChapterTitlesByDepth(stub_ui, 122)
+    eq(after_part.chapter_title, "Teil III",
+       "deepest should drop back to Teil III, not stay pinned on Nachspiel")
+    eq(after_part.chapter_titles_by_depth[1], "Teil III")
+    eq(after_part.chapter_titles_by_depth[2], nil,
+       "stale depth-2 title from previous section must be cleared")
+
+    -- Once Die Verlorenen opens at depth 2: depth-2 is the current sub-chapter.
+    local in_verlorenen = Tokens.getChapterTitlesByDepth(stub_ui, 200)
+    eq(in_verlorenen.chapter_title, "Die Verlorenen")
+    eq(in_verlorenen.chapter_titles_by_depth[1], "Teil III")
+    eq(in_verlorenen.chapter_titles_by_depth[2], "Die Verlorenen")
+end)
+
 test("getChapterTitlesByDepth: chapter_title_num/_name empty when no chapter title", function()
     local stub_ui = {
         toc = {


### PR DESCRIPTION
## Summary
- Fixes #50: `chapter_title` and `chapter_titles_by_depth[N]` stayed pinned to the last deep TOC entry once the reader passed it, when a book has a deeper section in the middle but shallower entries afterwards.
- Treats `chapter_titles_by_depth` as a live ancestor stack: a depth-`d` entry implicitly closes every slot at depth `>= d` before pushing itself. Deepest title is the highest slot still active after the walk.
- Reported and independently patched by @cgroi (reverse-walk variant); this PR uses a forward walk so `chapter_num` keeps pointing at the deepest covering entry rather than the shallowest ancestor.

## Test plan
- [x] Added regression test in `tests/_test_tokens.lua` mirroring the Teil II / Nachspiel / Teil III / Die Verlorenen TOC shape from #50
- [x] `lua tests/_test_tokens.lua` passes (175/175)
- [x] `luac -p bookends_tokens.lua` clean
- [ ] On-device verification with @cgroi's EPUB (pending their confirmation)