### PR TITLE
Localize weekday and month names across supported languages

### DIFF
--- a/bookends_tokens.lua
+++ b/bookends_tokens.lua
@@ -1,5 +1,6 @@
 local Device = require("device")
 local datetime = require("datetime")
+local _ = require("bookends_i18n").gettext
 local BAR_PLACEHOLDER = require("bookends_overlay_widget").BAR_PLACEHOLDER
 
 local Tokens = {}
@@ -513,35 +514,168 @@ local function splitAuthors(authors_raw)
     return list
 end
 
+local function getLocalizedWeekday(short, epoch)
+    local timestamp = epoch or os.time()
+    local now = os.date("*t", timestamp)
+    local source_names = short and {
+        "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
+    } or {
+        "Sunday", "Monday", "Tuesday", "Wednesday",
+        "Thursday", "Friday", "Saturday",
+    }
+
+    local source = source_names[now.wday] or ""
+    local translated = _(source)
+    if translated ~= source then
+        return translated
+    end
+
+    return os.date(short and "%a" or "%A", timestamp)
+end
+
+local MONTH_NAMES = {
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+}
+
+local MONTH_NAMES_SHORT = {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+}
+
+local function getLocalizedMonth(short, epoch)
+    local timestamp = epoch or os.time()
+    local now = os.date("*t", timestamp)
+    local source_names = short and MONTH_NAMES_SHORT or MONTH_NAMES
+    local source = source_names[now.month] or ""
+    local key = (short and "month.short." or "month.full.") .. source
+    local translated = _(key)
+
+    if translated ~= key then
+        return translated
+    end
+
+    return os.date(short and "%b" or "%B", timestamp)
+end
+
 -- Map KOReader UI language to a system locale for localized date strings.
--- Caches per language to avoid repeated locale probing.
-local _date_locale_cache = {} -- lang -> locale string or false
+-- Preserve the regional code first (for example pt_BR), then try generic fallbacks.
+local _date_locale_cache = {} -- language code -> locale string or false
 local function getDateLocale()
     local ok, GetText = pcall(require, "gettext")
     if not ok or not GetText or not GetText.current_lang or GetText.current_lang == "C" then
         return false
     end
-    local lang = GetText.current_lang:match("^([a-z]+)") -- e.g. "es" from "es_ES"
+
+    local current_lang = GetText.current_lang:gsub("-", "_")
+    local lang = current_lang:match("^([a-z]+)")
     if not lang or lang == "en" then
         return false
     end
-    if _date_locale_cache[lang] ~= nil then return _date_locale_cache[lang] end
-    -- Try common locale patterns
-    local candidates = {
-        lang .. "_" .. lang:upper() .. ".UTF-8",  -- es_ES.UTF-8
-        lang .. ".UTF-8",                           -- es.UTF-8
-    }
-    local saved = os.setlocale(nil, "time") -- save current locale
+    if _date_locale_cache[current_lang] ~= nil then
+        return _date_locale_cache[current_lang]
+    end
+
+    local candidates = {}
+    local seen = {}
+    local function add(locale)
+        if locale and locale ~= "" and not seen[locale] then
+            candidates[#candidates + 1] = locale
+            seen[locale] = true
+        end
+    end
+
+    if current_lang:find("_", 1, true) then
+        add(current_lang .. ".UTF-8")
+        add(current_lang .. ".utf8")
+        add(current_lang)
+    end
+    add(lang .. "_" .. lang:upper() .. ".UTF-8")
+    add(lang .. ".UTF-8")
+    add(lang)
+
+    local saved = os.setlocale(nil, "time")
     for _, loc in ipairs(candidates) do
         if os.setlocale(loc, "time") then
-            os.setlocale(saved or "C", "time") -- restore previous locale
-            _date_locale_cache[lang] = loc
+            os.setlocale(saved or "C", "time")
+            _date_locale_cache[current_lang] = loc
             return loc
         end
     end
-    if saved then os.setlocale(saved, "time") end -- restore after failed probes
-    _date_locale_cache[lang] = false
+    if saved then os.setlocale(saved, "time") end
+    _date_locale_cache[current_lang] = false
     return false
+end
+
+-- Format strftime text while resolving weekday and month names through Bookends
+-- translations first. Missing translations retain the system-locale fallback.
+local function formatLocalizedDate(fmt, epoch)
+    if not fmt or fmt == "" then return "" end
+
+    local timestamp = epoch or os.time()
+    local loc = getDateLocale()
+    local saved_locale
+    if loc then
+        saved_locale = os.setlocale(nil, "time")
+        os.setlocale(loc, "time")
+    end
+
+    local output = {}
+    local native = {}
+
+    local function flushNative()
+        if #native == 0 then return end
+        output[#output + 1] = os.date(table.concat(native), timestamp) or ""
+        native = {}
+    end
+
+    local i = 1
+    while i <= #fmt do
+        local char = fmt:sub(i, i)
+        if char ~= "%" or i == #fmt then
+            native[#native + 1] = char
+            i = i + 1
+        else
+            local j = i + 1
+            local next_char = fmt:sub(j, j)
+            if next_char == "%" then
+                native[#native + 1] = "%%"
+                i = i + 2
+            else
+                while j <= #fmt and fmt:sub(j, j):match("[-_0%^#EO%d]") do
+                    j = j + 1
+                end
+                if j > #fmt then
+                    native[#native + 1] = fmt:sub(i)
+                    break
+                end
+
+                local directive = fmt:sub(i, j)
+                local spec = fmt:sub(j, j)
+                if directive == "%A" or directive == "%a"
+                        or directive == "%B" or directive == "%b"
+                        or directive == "%h" then
+                    flushNative()
+                    if spec == "A" then
+                        output[#output + 1] = getLocalizedWeekday(false, timestamp)
+                    elseif spec == "a" then
+                        output[#output + 1] = getLocalizedWeekday(true, timestamp)
+                    elseif spec == "B" then
+                        output[#output + 1] = getLocalizedMonth(false, timestamp)
+                    else
+                        output[#output + 1] = getLocalizedMonth(true, timestamp)
+                    end
+                else
+                    native[#native + 1] = directive
+                end
+                i = j + 1
+            end
+        end
+    end
+
+    flushNative()
+    if saved_locale then os.setlocale(saved_locale, "time") end
+    return table.concat(output)
 end
 
 -- Format an ETA epoch for the %*_time_left_eta tokens. When brace_fmt is nil,
@@ -552,15 +686,7 @@ end
 local function formatEtaEpoch(epoch, brace_fmt)
     if not epoch then return "" end
     if brace_fmt and brace_fmt ~= "" then
-        local loc = getDateLocale()
-        local saved
-        if loc then
-            saved = os.setlocale(nil, "time")
-            os.setlocale(loc, "time")
-        end
-        local out = os.date(brace_fmt, epoch) or ""
-        if saved then os.setlocale(saved, "time") end
-        return tostring(out)
+        return formatLocalizedDate(brace_fmt, epoch)
     end
     local twelve = G_reader_settings and G_reader_settings:isTrue("twelve_hour_clock") or false
     return datetime.secondsToHour(epoch, twelve)
@@ -573,15 +699,7 @@ end
 local function formatFinishDate(epoch, brace_fmt)
     if not epoch then return "" end
     local fmt = (brace_fmt and brace_fmt ~= "") and brace_fmt or "%d %b"
-    local loc = getDateLocale()
-    local saved
-    if loc then
-        saved = os.setlocale(nil, "time")
-        os.setlocale(loc, "time")
-    end
-    local out = os.date(fmt, epoch) or ""
-    if saved then os.setlocale(saved, "time") end
-    return tostring(out)
+    return formatLocalizedDate(fmt, epoch)
 end
 
 --- Compute chapter tick fractions as {fraction, width, depth} triples.
@@ -1662,16 +1780,7 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
             return "%__pcfilter" .. #plugin_content_filters
         end
         if name == "datetime" then
-            -- Strftime escape hatch. Respect device locale (see getDateLocale).
-            local loc = getDateLocale()
-            local saved_locale
-            if loc then
-                saved_locale = os.setlocale(nil, "time")
-                os.setlocale(loc, "time")
-            end
-            local formatted = os.date(content) or ""
-            if saved_locale then os.setlocale(saved_locale, "time") end
-            return formatted
+            return formatLocalizedDate(content)
         end
         -- %chap_time_left_eta{<strftime>} / %book_time_left_eta{<strftime>} /
         -- %book_finish_date{<strftime>}. Stash format and rewrite to bareword
@@ -1756,16 +1865,7 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
         r = r:gsub("%%bar", preview.bar)
         -- Handle %datetime{...} — in preview mode, actually expand it (not a placeholder)
         r = r:gsub("%%datetime(%b{})", function(brace)
-            local content = brace:sub(2, -2)
-            local loc = getDateLocale()
-            local saved_locale
-            if loc then
-                saved_locale = os.setlocale(nil, "time")
-                os.setlocale(loc, "time")
-            end
-            local formatted = os.date(content) or ""
-            if saved_locale then os.setlocale(saved_locale, "time") end
-            return formatted
+            return formatLocalizedDate(brace:sub(2, -2))
         end)
         -- Live-preview braced ETA tokens with dummy offsets so the user can
         -- see their strftime format render in the line editor. Chapter uses
@@ -2259,21 +2359,11 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
     local date_weekday = ""
     local date_weekday_short = ""
     if needs("date", "date_long", "date_numeric", "weekday", "weekday_short") then
-        -- Use device language for day/month names if available
-        local loc = getDateLocale()
-        local saved_locale
-        if loc then
-            saved_locale = os.setlocale(nil, "time")
-            os.setlocale(loc, "time")
-        end
-        if needs("date") then date_short = os.date("%d %b") end
-        if needs("date_long") then date_long = os.date("%d %B %Y") end
+        if needs("date") then date_short = formatLocalizedDate("%d %b") end
+        if needs("date_long") then date_long = formatLocalizedDate("%d %B %Y") end
         if needs("date_numeric") then date_num = os.date("%d/%m/%Y") end
-        if needs("weekday") then date_weekday = os.date("%A") end
-        if needs("weekday_short") then date_weekday_short = os.date("%a") end
-        if saved_locale then
-            os.setlocale(saved_locale, "time")
-        end
+        if needs("weekday") then date_weekday = formatLocalizedDate("%A") end
+        if needs("weekday_short") then date_weekday_short = formatLocalizedDate("%a") end
     end
 
     -- Session reading time (skip-aware via ReaderStatistics with fallback

--- a/locale/bg_BG.po
+++ b/locale/bg_BG.po
@@ -3032,3 +3032,120 @@ msgstr ""
 
 #~ msgid "wifi — on / off"
 #~ msgstr "wifi — вкл. / изкл."
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "неделя"
+
+msgid "Monday"
+msgstr "понеделник"
+
+msgid "Tuesday"
+msgstr "вторник"
+
+msgid "Wednesday"
+msgstr "сряда"
+
+msgid "Thursday"
+msgstr "четвъртък"
+
+msgid "Friday"
+msgstr "петък"
+
+msgid "Saturday"
+msgstr "събота"
+
+msgid "Sun"
+msgstr "нд"
+
+msgid "Mon"
+msgstr "пн"
+
+msgid "Tue"
+msgstr "вт"
+
+msgid "Wed"
+msgstr "ср"
+
+msgid "Thu"
+msgstr "чт"
+
+msgid "Fri"
+msgstr "пт"
+
+msgid "Sat"
+msgstr "сб"
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "януари"
+
+msgid "month.full.February"
+msgstr "февруари"
+
+msgid "month.full.March"
+msgstr "март"
+
+msgid "month.full.April"
+msgstr "април"
+
+msgid "month.full.May"
+msgstr "май"
+
+msgid "month.full.June"
+msgstr "юни"
+
+msgid "month.full.July"
+msgstr "юли"
+
+msgid "month.full.August"
+msgstr "август"
+
+msgid "month.full.September"
+msgstr "септември"
+
+msgid "month.full.October"
+msgstr "октомври"
+
+msgid "month.full.November"
+msgstr "ноември"
+
+msgid "month.full.December"
+msgstr "декември"
+
+msgid "month.short.Jan"
+msgstr "яну"
+
+msgid "month.short.Feb"
+msgstr "фев"
+
+msgid "month.short.Mar"
+msgstr "март"
+
+msgid "month.short.Apr"
+msgstr "апр"
+
+msgid "month.short.May"
+msgstr "май"
+
+msgid "month.short.Jun"
+msgstr "юни"
+
+msgid "month.short.Jul"
+msgstr "юли"
+
+msgid "month.short.Aug"
+msgstr "авг"
+
+msgid "month.short.Sep"
+msgstr "сеп"
+
+msgid "month.short.Oct"
+msgstr "окт"
+
+msgid "month.short.Nov"
+msgstr "ное"
+
+msgid "month.short.Dec"
+msgstr "дек"

--- a/locale/de.po
+++ b/locale/de.po
@@ -3109,3 +3109,120 @@ msgstr ""
 
 #~ msgid "wifi — on / off"
 #~ msgstr "wifi — an / aus"
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "Sonntag"
+
+msgid "Monday"
+msgstr "Montag"
+
+msgid "Tuesday"
+msgstr "Dienstag"
+
+msgid "Wednesday"
+msgstr "Mittwoch"
+
+msgid "Thursday"
+msgstr "Donnerstag"
+
+msgid "Friday"
+msgstr "Freitag"
+
+msgid "Saturday"
+msgstr "Samstag"
+
+msgid "Sun"
+msgstr "So."
+
+msgid "Mon"
+msgstr "Mo."
+
+msgid "Tue"
+msgstr "Di."
+
+msgid "Wed"
+msgstr "Mi."
+
+msgid "Thu"
+msgstr "Do."
+
+msgid "Fri"
+msgstr "Fr."
+
+msgid "Sat"
+msgstr "Sa."
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "Januar"
+
+msgid "month.full.February"
+msgstr "Februar"
+
+msgid "month.full.March"
+msgstr "März"
+
+msgid "month.full.April"
+msgstr "April"
+
+msgid "month.full.May"
+msgstr "Mai"
+
+msgid "month.full.June"
+msgstr "Juni"
+
+msgid "month.full.July"
+msgstr "Juli"
+
+msgid "month.full.August"
+msgstr "August"
+
+msgid "month.full.September"
+msgstr "September"
+
+msgid "month.full.October"
+msgstr "Oktober"
+
+msgid "month.full.November"
+msgstr "November"
+
+msgid "month.full.December"
+msgstr "Dezember"
+
+msgid "month.short.Jan"
+msgstr "Jan."
+
+msgid "month.short.Feb"
+msgstr "Feb."
+
+msgid "month.short.Mar"
+msgstr "März"
+
+msgid "month.short.Apr"
+msgstr "Apr."
+
+msgid "month.short.May"
+msgstr "Mai"
+
+msgid "month.short.Jun"
+msgstr "Juni"
+
+msgid "month.short.Jul"
+msgstr "Juli"
+
+msgid "month.short.Aug"
+msgstr "Aug."
+
+msgid "month.short.Sep"
+msgstr "Sept."
+
+msgid "month.short.Oct"
+msgstr "Okt."
+
+msgid "month.short.Nov"
+msgstr "Nov."
+
+msgid "month.short.Dec"
+msgstr "Dez."

--- a/locale/en_GB.po
+++ b/locale/en_GB.po
@@ -2478,3 +2478,120 @@ msgstr ""
 #~ "\n"
 #~ "An inline [c=#RRGGBB]…[/c] tag in a line overrides the icon colour for "
 #~ "any glyphs inside it."
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "Sunday"
+
+msgid "Monday"
+msgstr "Monday"
+
+msgid "Tuesday"
+msgstr "Tuesday"
+
+msgid "Wednesday"
+msgstr "Wednesday"
+
+msgid "Thursday"
+msgstr "Thursday"
+
+msgid "Friday"
+msgstr "Friday"
+
+msgid "Saturday"
+msgstr "Saturday"
+
+msgid "Sun"
+msgstr "Sun"
+
+msgid "Mon"
+msgstr "Mon"
+
+msgid "Tue"
+msgstr "Tue"
+
+msgid "Wed"
+msgstr "Wed"
+
+msgid "Thu"
+msgstr "Thu"
+
+msgid "Fri"
+msgstr "Fri"
+
+msgid "Sat"
+msgstr "Sat"
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "January"
+
+msgid "month.full.February"
+msgstr "February"
+
+msgid "month.full.March"
+msgstr "March"
+
+msgid "month.full.April"
+msgstr "April"
+
+msgid "month.full.May"
+msgstr "May"
+
+msgid "month.full.June"
+msgstr "June"
+
+msgid "month.full.July"
+msgstr "July"
+
+msgid "month.full.August"
+msgstr "August"
+
+msgid "month.full.September"
+msgstr "September"
+
+msgid "month.full.October"
+msgstr "October"
+
+msgid "month.full.November"
+msgstr "November"
+
+msgid "month.full.December"
+msgstr "December"
+
+msgid "month.short.Jan"
+msgstr "Jan"
+
+msgid "month.short.Feb"
+msgstr "Feb"
+
+msgid "month.short.Mar"
+msgstr "Mar"
+
+msgid "month.short.Apr"
+msgstr "Apr"
+
+msgid "month.short.May"
+msgstr "May"
+
+msgid "month.short.Jun"
+msgstr "Jun"
+
+msgid "month.short.Jul"
+msgstr "Jul"
+
+msgid "month.short.Aug"
+msgstr "Aug"
+
+msgid "month.short.Sep"
+msgstr "Sept"
+
+msgid "month.short.Oct"
+msgstr "Oct"
+
+msgid "month.short.Nov"
+msgstr "Nov"
+
+msgid "month.short.Dec"
+msgstr "Dec"

--- a/locale/es.po
+++ b/locale/es.po
@@ -3096,3 +3096,120 @@ msgstr ""
 
 #~ msgid "wifi — on / off"
 #~ msgstr "wifi — on / off"
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "domingo"
+
+msgid "Monday"
+msgstr "lunes"
+
+msgid "Tuesday"
+msgstr "martes"
+
+msgid "Wednesday"
+msgstr "miércoles"
+
+msgid "Thursday"
+msgstr "jueves"
+
+msgid "Friday"
+msgstr "viernes"
+
+msgid "Saturday"
+msgstr "sábado"
+
+msgid "Sun"
+msgstr "dom"
+
+msgid "Mon"
+msgstr "lun"
+
+msgid "Tue"
+msgstr "mar"
+
+msgid "Wed"
+msgstr "mié"
+
+msgid "Thu"
+msgstr "jue"
+
+msgid "Fri"
+msgstr "vie"
+
+msgid "Sat"
+msgstr "sáb"
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "enero"
+
+msgid "month.full.February"
+msgstr "febrero"
+
+msgid "month.full.March"
+msgstr "marzo"
+
+msgid "month.full.April"
+msgstr "abril"
+
+msgid "month.full.May"
+msgstr "mayo"
+
+msgid "month.full.June"
+msgstr "junio"
+
+msgid "month.full.July"
+msgstr "julio"
+
+msgid "month.full.August"
+msgstr "agosto"
+
+msgid "month.full.September"
+msgstr "septiembre"
+
+msgid "month.full.October"
+msgstr "octubre"
+
+msgid "month.full.November"
+msgstr "noviembre"
+
+msgid "month.full.December"
+msgstr "diciembre"
+
+msgid "month.short.Jan"
+msgstr "ene"
+
+msgid "month.short.Feb"
+msgstr "feb"
+
+msgid "month.short.Mar"
+msgstr "mar"
+
+msgid "month.short.Apr"
+msgstr "abr"
+
+msgid "month.short.May"
+msgstr "may"
+
+msgid "month.short.Jun"
+msgstr "jun"
+
+msgid "month.short.Jul"
+msgstr "jul"
+
+msgid "month.short.Aug"
+msgstr "ago"
+
+msgid "month.short.Sep"
+msgstr "sept"
+
+msgid "month.short.Oct"
+msgstr "oct"
+
+msgid "month.short.Nov"
+msgstr "nov"
+
+msgid "month.short.Dec"
+msgstr "dic"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -3101,3 +3101,120 @@ msgstr ""
 
 #~ msgid "wifi — on / off"
 #~ msgstr "wifi — activé / désactivé"
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "dimanche"
+
+msgid "Monday"
+msgstr "lundi"
+
+msgid "Tuesday"
+msgstr "mardi"
+
+msgid "Wednesday"
+msgstr "mercredi"
+
+msgid "Thursday"
+msgstr "jeudi"
+
+msgid "Friday"
+msgstr "vendredi"
+
+msgid "Saturday"
+msgstr "samedi"
+
+msgid "Sun"
+msgstr "dim."
+
+msgid "Mon"
+msgstr "lun."
+
+msgid "Tue"
+msgstr "mar."
+
+msgid "Wed"
+msgstr "mer."
+
+msgid "Thu"
+msgstr "jeu."
+
+msgid "Fri"
+msgstr "ven."
+
+msgid "Sat"
+msgstr "sam."
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "janvier"
+
+msgid "month.full.February"
+msgstr "février"
+
+msgid "month.full.March"
+msgstr "mars"
+
+msgid "month.full.April"
+msgstr "avril"
+
+msgid "month.full.May"
+msgstr "mai"
+
+msgid "month.full.June"
+msgstr "juin"
+
+msgid "month.full.July"
+msgstr "juillet"
+
+msgid "month.full.August"
+msgstr "août"
+
+msgid "month.full.September"
+msgstr "septembre"
+
+msgid "month.full.October"
+msgstr "octobre"
+
+msgid "month.full.November"
+msgstr "novembre"
+
+msgid "month.full.December"
+msgstr "décembre"
+
+msgid "month.short.Jan"
+msgstr "janv."
+
+msgid "month.short.Feb"
+msgstr "févr."
+
+msgid "month.short.Mar"
+msgstr "mars"
+
+msgid "month.short.Apr"
+msgstr "avr."
+
+msgid "month.short.May"
+msgstr "mai"
+
+msgid "month.short.Jun"
+msgstr "juin"
+
+msgid "month.short.Jul"
+msgstr "juil."
+
+msgid "month.short.Aug"
+msgstr "août"
+
+msgid "month.short.Sep"
+msgstr "sept."
+
+msgid "month.short.Oct"
+msgstr "oct."
+
+msgid "month.short.Nov"
+msgstr "nov."
+
+msgid "month.short.Dec"
+msgstr "déc."

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -3101,3 +3101,120 @@ msgstr ""
 
 #~ msgid "wifi — on / off"
 #~ msgstr "wifi — be / ki"
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "vasárnap"
+
+msgid "Monday"
+msgstr "hétfő"
+
+msgid "Tuesday"
+msgstr "kedd"
+
+msgid "Wednesday"
+msgstr "szerda"
+
+msgid "Thursday"
+msgstr "csütörtök"
+
+msgid "Friday"
+msgstr "péntek"
+
+msgid "Saturday"
+msgstr "szombat"
+
+msgid "Sun"
+msgstr "V"
+
+msgid "Mon"
+msgstr "H"
+
+msgid "Tue"
+msgstr "K"
+
+msgid "Wed"
+msgstr "Sze"
+
+msgid "Thu"
+msgstr "Cs"
+
+msgid "Fri"
+msgstr "P"
+
+msgid "Sat"
+msgstr "Szo"
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "január"
+
+msgid "month.full.February"
+msgstr "február"
+
+msgid "month.full.March"
+msgstr "március"
+
+msgid "month.full.April"
+msgstr "április"
+
+msgid "month.full.May"
+msgstr "május"
+
+msgid "month.full.June"
+msgstr "június"
+
+msgid "month.full.July"
+msgstr "július"
+
+msgid "month.full.August"
+msgstr "augusztus"
+
+msgid "month.full.September"
+msgstr "szeptember"
+
+msgid "month.full.October"
+msgstr "október"
+
+msgid "month.full.November"
+msgstr "november"
+
+msgid "month.full.December"
+msgstr "december"
+
+msgid "month.short.Jan"
+msgstr "jan."
+
+msgid "month.short.Feb"
+msgstr "febr."
+
+msgid "month.short.Mar"
+msgstr "márc."
+
+msgid "month.short.Apr"
+msgstr "ápr."
+
+msgid "month.short.May"
+msgstr "máj."
+
+msgid "month.short.Jun"
+msgstr "jún."
+
+msgid "month.short.Jul"
+msgstr "júl."
+
+msgid "month.short.Aug"
+msgstr "aug."
+
+msgid "month.short.Sep"
+msgstr "szept."
+
+msgid "month.short.Oct"
+msgstr "okt."
+
+msgid "month.short.Nov"
+msgstr "nov."
+
+msgid "month.short.Dec"
+msgstr "dec."

--- a/locale/it.po
+++ b/locale/it.po
@@ -3097,3 +3097,120 @@ msgstr ""
 
 #~ msgid "wifi — on / off"
 #~ msgstr "wifi — on / off"
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "domenica"
+
+msgid "Monday"
+msgstr "lunedì"
+
+msgid "Tuesday"
+msgstr "martedì"
+
+msgid "Wednesday"
+msgstr "mercoledì"
+
+msgid "Thursday"
+msgstr "giovedì"
+
+msgid "Friday"
+msgstr "venerdì"
+
+msgid "Saturday"
+msgstr "sabato"
+
+msgid "Sun"
+msgstr "dom"
+
+msgid "Mon"
+msgstr "lun"
+
+msgid "Tue"
+msgstr "mar"
+
+msgid "Wed"
+msgstr "mer"
+
+msgid "Thu"
+msgstr "gio"
+
+msgid "Fri"
+msgstr "ven"
+
+msgid "Sat"
+msgstr "sab"
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "gennaio"
+
+msgid "month.full.February"
+msgstr "febbraio"
+
+msgid "month.full.March"
+msgstr "marzo"
+
+msgid "month.full.April"
+msgstr "aprile"
+
+msgid "month.full.May"
+msgstr "maggio"
+
+msgid "month.full.June"
+msgstr "giugno"
+
+msgid "month.full.July"
+msgstr "luglio"
+
+msgid "month.full.August"
+msgstr "agosto"
+
+msgid "month.full.September"
+msgstr "settembre"
+
+msgid "month.full.October"
+msgstr "ottobre"
+
+msgid "month.full.November"
+msgstr "novembre"
+
+msgid "month.full.December"
+msgstr "dicembre"
+
+msgid "month.short.Jan"
+msgstr "gen"
+
+msgid "month.short.Feb"
+msgstr "feb"
+
+msgid "month.short.Mar"
+msgstr "mar"
+
+msgid "month.short.Apr"
+msgstr "apr"
+
+msgid "month.short.May"
+msgstr "mag"
+
+msgid "month.short.Jun"
+msgstr "giu"
+
+msgid "month.short.Jul"
+msgstr "lug"
+
+msgid "month.short.Aug"
+msgstr "ago"
+
+msgid "month.short.Sep"
+msgstr "set"
+
+msgid "month.short.Oct"
+msgstr "ott"
+
+msgid "month.short.Nov"
+msgstr "nov"
+
+msgid "month.short.Dec"
+msgstr "dic"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -2539,6 +2539,123 @@ msgstr ""
 "Sobreposições de texto configuráveis nos cantos e bordas da tela com "
 "expansão de tokens e suporte a ícones."
 
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "domingo"
+
+msgid "Monday"
+msgstr "segunda-feira"
+
+msgid "Tuesday"
+msgstr "terça-feira"
+
+msgid "Wednesday"
+msgstr "quarta-feira"
+
+msgid "Thursday"
+msgstr "quinta-feira"
+
+msgid "Friday"
+msgstr "sexta-feira"
+
+msgid "Saturday"
+msgstr "sábado"
+
+msgid "Sun"
+msgstr "dom."
+
+msgid "Mon"
+msgstr "seg."
+
+msgid "Tue"
+msgstr "ter."
+
+msgid "Wed"
+msgstr "qua."
+
+msgid "Thu"
+msgstr "qui."
+
+msgid "Fri"
+msgstr "sex."
+
+msgid "Sat"
+msgstr "sáb."
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "janeiro"
+
+msgid "month.full.February"
+msgstr "fevereiro"
+
+msgid "month.full.March"
+msgstr "março"
+
+msgid "month.full.April"
+msgstr "abril"
+
+msgid "month.full.May"
+msgstr "maio"
+
+msgid "month.full.June"
+msgstr "junho"
+
+msgid "month.full.July"
+msgstr "julho"
+
+msgid "month.full.August"
+msgstr "agosto"
+
+msgid "month.full.September"
+msgstr "setembro"
+
+msgid "month.full.October"
+msgstr "outubro"
+
+msgid "month.full.November"
+msgstr "novembro"
+
+msgid "month.full.December"
+msgstr "dezembro"
+
+msgid "month.short.Jan"
+msgstr "jan."
+
+msgid "month.short.Feb"
+msgstr "fev."
+
+msgid "month.short.Mar"
+msgstr "mar."
+
+msgid "month.short.Apr"
+msgstr "abr."
+
+msgid "month.short.May"
+msgstr "mai."
+
+msgid "month.short.Jun"
+msgstr "jun."
+
+msgid "month.short.Jul"
+msgstr "jul."
+
+msgid "month.short.Aug"
+msgstr "ago."
+
+msgid "month.short.Sep"
+msgstr "set."
+
+msgid "month.short.Oct"
+msgstr "out."
+
+msgid "month.short.Nov"
+msgstr "nov."
+
+msgid "month.short.Dec"
+msgstr "dez."
+
 #~ msgid "Wi-Fi is not enabled."
 #~ msgstr "Wi-Fi não está ativado."
 

--- a/locale/pt_PT.po
+++ b/locale/pt_PT.po
@@ -2548,3 +2548,120 @@ msgid ""
 msgstr ""
 "Camadas de texto configuráveis nos cantos e extremidades do ecrã com suporte "
 "a expansão de variáveis e ícones."
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "domingo"
+
+msgid "Monday"
+msgstr "segunda-feira"
+
+msgid "Tuesday"
+msgstr "terça-feira"
+
+msgid "Wednesday"
+msgstr "quarta-feira"
+
+msgid "Thursday"
+msgstr "quinta-feira"
+
+msgid "Friday"
+msgstr "sexta-feira"
+
+msgid "Saturday"
+msgstr "sábado"
+
+msgid "Sun"
+msgstr "dom."
+
+msgid "Mon"
+msgstr "seg."
+
+msgid "Tue"
+msgstr "ter."
+
+msgid "Wed"
+msgstr "qua."
+
+msgid "Thu"
+msgstr "qui."
+
+msgid "Fri"
+msgstr "sex."
+
+msgid "Sat"
+msgstr "sáb."
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "janeiro"
+
+msgid "month.full.February"
+msgstr "fevereiro"
+
+msgid "month.full.March"
+msgstr "março"
+
+msgid "month.full.April"
+msgstr "abril"
+
+msgid "month.full.May"
+msgstr "maio"
+
+msgid "month.full.June"
+msgstr "junho"
+
+msgid "month.full.July"
+msgstr "julho"
+
+msgid "month.full.August"
+msgstr "agosto"
+
+msgid "month.full.September"
+msgstr "setembro"
+
+msgid "month.full.October"
+msgstr "outubro"
+
+msgid "month.full.November"
+msgstr "novembro"
+
+msgid "month.full.December"
+msgstr "dezembro"
+
+msgid "month.short.Jan"
+msgstr "jan."
+
+msgid "month.short.Feb"
+msgstr "fev."
+
+msgid "month.short.Mar"
+msgstr "mar."
+
+msgid "month.short.Apr"
+msgstr "abr."
+
+msgid "month.short.May"
+msgstr "mai."
+
+msgid "month.short.Jun"
+msgstr "jun."
+
+msgid "month.short.Jul"
+msgstr "jul."
+
+msgid "month.short.Aug"
+msgstr "ago."
+
+msgid "month.short.Sep"
+msgstr "set."
+
+msgid "month.short.Oct"
+msgstr "out."
+
+msgid "month.short.Nov"
+msgstr "nov."
+
+msgid "month.short.Dec"
+msgstr "dez."

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -2509,3 +2509,120 @@ msgid ""
 "and icon support."
 msgstr ""
 "可以在屏幕四周显示自定义文字，并自动读取系统信息，除了文字，还支持图标。"
+
+# Weekday names used by bookends_tokens.lua
+msgid "Sunday"
+msgstr "星期日"
+
+msgid "Monday"
+msgstr "星期一"
+
+msgid "Tuesday"
+msgstr "星期二"
+
+msgid "Wednesday"
+msgstr "星期三"
+
+msgid "Thursday"
+msgstr "星期四"
+
+msgid "Friday"
+msgstr "星期五"
+
+msgid "Saturday"
+msgstr "星期六"
+
+msgid "Sun"
+msgstr "周日"
+
+msgid "Mon"
+msgstr "周一"
+
+msgid "Tue"
+msgstr "周二"
+
+msgid "Wed"
+msgstr "周三"
+
+msgid "Thu"
+msgstr "周四"
+
+msgid "Fri"
+msgstr "周五"
+
+msgid "Sat"
+msgstr "周六"
+
+
+# Month names used by bookends_tokens.lua
+msgid "month.full.January"
+msgstr "一月"
+
+msgid "month.full.February"
+msgstr "二月"
+
+msgid "month.full.March"
+msgstr "三月"
+
+msgid "month.full.April"
+msgstr "四月"
+
+msgid "month.full.May"
+msgstr "五月"
+
+msgid "month.full.June"
+msgstr "六月"
+
+msgid "month.full.July"
+msgstr "七月"
+
+msgid "month.full.August"
+msgstr "八月"
+
+msgid "month.full.September"
+msgstr "九月"
+
+msgid "month.full.October"
+msgstr "十月"
+
+msgid "month.full.November"
+msgstr "十一月"
+
+msgid "month.full.December"
+msgstr "十二月"
+
+msgid "month.short.Jan"
+msgstr "1月"
+
+msgid "month.short.Feb"
+msgstr "2月"
+
+msgid "month.short.Mar"
+msgstr "3月"
+
+msgid "month.short.Apr"
+msgstr "4月"
+
+msgid "month.short.May"
+msgstr "5月"
+
+msgid "month.short.Jun"
+msgstr "6月"
+
+msgid "month.short.Jul"
+msgstr "7月"
+
+msgid "month.short.Aug"
+msgstr "8月"
+
+msgid "month.short.Sep"
+msgstr "9月"
+
+msgid "month.short.Oct"
+msgstr "10月"
+
+msgid "month.short.Nov"
+msgstr "11月"
+
+msgid "month.short.Dec"
+msgstr "12月"


### PR DESCRIPTION
This PR adds `gettext-based` localization for full and abbreviated weekday and month names in Bookends. It also preserves regional locale codes, adds safe locale fallbacks, and updates the available PO catalogs with the new date translations.