### PR TITLE
fix(mem): fallback for MemAvailable on old kernels (pre-3.14)

### DIFF
--- a/bookends_tokens.lua
+++ b/bookends_tokens.lua
@@ -2715,16 +2715,26 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
     if needs("mem") then
         local meminfo = io.open("/proc/meminfo", "r")
         if meminfo then
-            local total, available
+            local total, memfree, buffers, cached, available
             for line in meminfo:lines() do
                 if line:match("^MemTotal:") then
                     total = tonumber(line:match("(%d+)"))
                 elseif line:match("^MemAvailable:") then
                     available = tonumber(line:match("(%d+)"))
+                elseif line:match("^MemFree:") then
+                    memfree = tonumber(line:match("(%d+)"))
+                elseif line:match("^Buffers:") then
+                    buffers = tonumber(line:match("(%d+)"))
+                elseif line:match("^Cached:") then
+                    cached = tonumber(line:match("(%d+)"))
                 end
                 if total and available then break end
             end
             meminfo:close()
+            -- Fallback for kernels without MemAvailable (e.g. Kindle KPW3 2.6.x)
+            if total and not available and memfree then
+                available = memfree + (buffers or 0) + (cached or 0)
+            end
             if total and available and total > 0 then
                 mem_usage = math.floor((total - available) / total * 100) .. "%"
             end


### PR DESCRIPTION
## Problem

The `%mem` token reads `/proc/meminfo` and relies on the `MemAvailable:` field, which was introduced in Linux 3.14. On devices running older kernels (e.g. Kindle PaperWhite 3 with 2.6.x), `MemAvailable:` is absent from `/proc/meminfo`, causing the token to silently produce an empty string and auto-hide. No error in crash.log, the token just disappears.

## Root cause

`bookends_tokens.lua` only parses `MemTotal:` and `MemAvailable:`. When `MemAvailable:` is missing, the `available` variable stays nil, the `if total and available` guard fails, and `mem_usage` remains empty string.

## Fix

Add a fallback that estimates available memory as:

```
MemFree + Buffers + Cached
```

This is the standard pre-3.14 approximation used by free(1) and procps-ng. When `MemAvailable:` is present (kernel >= 3.14), it is used directly and the fallback never triggers, so zero behavior change for modern devices.

## Affected devices

All Kindle models with kernels older than 3.14, including:
- Kindle PaperWhite 3 (2.6.x)
- Other older Kindle variants on 2.6.x / 3.x kernels

## Testing

Verified on Kindle PaperWhite 3 (512MB RAM, Linux 2.6.x):
- Before: `%mem` renders empty (token auto-hidden)
- After: `%mem` renders correct system-wide usage percentage

The fallback values (MemFree, Buffers, Cached) are present in `/proc/meminfo` on all Linux kernel versions.