### PR TITLE
fix(sysused): add MemFree+Buffers+Cached fallback for old kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ Tokens are placeholders that expand to live values. Type `%` followed by a name,
 | `%warmth_icon` | Warmth icon (dynamic) | Shown on devices with a warm frontlight |
 | `%nightmode` | Night-mode icon (dynamic) | Moon when inverted, sun when not |
 | `%mem` | RAM usage percentage | *33%* |
-| `%sysused` | System memory used, in MiB | *84 MiB* |
-| `%ram` | RAM usage in MiB | *128 MiB* |
+| `%sysused` | System memory used, in MiB | *84M* |
+| `%ram` | RAM usage in MiB | *128M* |
 | `%disk` | Free disk space | *2.4 GB* |
 | `%invert` | Page-turn direction indicator | Changes when inverted |
 

--- a/bookends_tokens.lua
+++ b/bookends_tokens.lua
@@ -3299,17 +3299,21 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
     if needs("sysused") then
         local meminfo = io.open("/proc/meminfo", "r")
         if meminfo then
-            local total, available, memfree
+            local total, available, memfree, buffers, cached
             for line in meminfo:lines() do
                 if line:match("^MemTotal:") then total = tonumber(line:match("(%d+)"))
                 elseif line:match("^MemAvailable:") then available = tonumber(line:match("(%d+)"))
-                elseif line:match("^MemFree:") then memfree = tonumber(line:match("(%d+)")) end
+                elseif line:match("^MemFree:") then memfree = tonumber(line:match("(%d+)"))
+                elseif line:match("^Buffers:") then buffers = tonumber(line:match("(%d+)"))
+                elseif line:match("^Cached:") then cached = tonumber(line:match("(%d+)")) end
             end
             meminfo:close()
-            available = available or memfree
-            if total and available then
+            -- Fallback to MemFree+Buffers+Cached when MemAvailable absent
+            -- (same as KOReader util.calcFreeMem; needed on pre-3.14 KPW3 2.6.x)
+            local free_kb = available or ((memfree or 0) + (buffers or 0) + (cached or 0))
+            if total and free_kb then
                 -- /proc/meminfo is in kB; Semantics.sysused takes bytes used.
-                sysused_str = Semantics.sysused((total - available) * 1024)
+                sysused_str = Semantics.sysused((total - free_kb) * 1024)
             end
         end
     end

--- a/bookends_tokens.lua
+++ b/bookends_tokens.lua
@@ -3308,12 +3308,17 @@ function Tokens.expand(format_str, ui, session_elapsed, session_pages_read, prev
                 elseif line:match("^Cached:") then cached = tonumber(line:match("(%d+)")) end
             end
             meminfo:close()
-            -- Fallback to MemFree+Buffers+Cached when MemAvailable absent
-            -- (same as KOReader util.calcFreeMem; needed on pre-3.14 KPW3 2.6.x)
-            local free_kb = available or ((memfree or 0) + (buffers or 0) + (cached or 0))
-            if total and free_kb then
+            -- Fallback for kernels without MemAvailable (e.g. Kindle KPW3 2.6.x).
+            -- MemFree alone badly overstates usage on a small device: the kernel
+            -- caches nearly all otherwise-free RAM for file I/O, but that cache is
+            -- reclaimable and available to us. Same shape as the %mem fallback
+            -- above, so the two parsers cannot drift apart again.
+            if total and not available and memfree then
+                available = memfree + (buffers or 0) + (cached or 0)
+            end
+            if total and available and total > 0 then
                 -- /proc/meminfo is in kB; Semantics.sysused takes bytes used.
-                sysused_str = Semantics.sysused((total - free_kb) * 1024)
+                sysused_str = Semantics.sysused((total - available) * 1024)
             end
         end
     end

--- a/tests/_test_metadata_tokens.lua
+++ b/tests/_test_metadata_tokens.lua
@@ -179,10 +179,10 @@ test("%quote is empty when the book has no highlights", function()
     eq(ex("%quote_source", ui), "")
 end)
 
-test("%sysused reports memory in MiB", function()
+test("%sysused reports memory with the short M suffix", function()
     local got = ex("%sysused")
-    assert(got:find("MiB", 1, true) or got == "",
-           "expected a MiB value or empty, got: " .. got)
+    assert(got:match("^%d+M$") or got == "",
+           "expected a MiB value with the short M suffix or empty, got: " .. got)
 end)
 
 print(pass .. " passed, " .. fail .. " failed")

--- a/token_conformance.lua
+++ b/token_conformance.lua
@@ -107,7 +107,8 @@ return {
     { fn = "mem", args = {nil, nil},  n = 2, expect = "" },
 
     -- %sysused: MiB, rounded, takes bytes used.
-    { fn = "sysused", args = {88080384}, n = 1, expect = "84 MiB" },
+    { fn = "sysused", args = {88080384}, n = 1, expect = "84M",
+      why = "short M suffix, not MiB - same call as %ram (#348)" },
     { fn = "sysused", args = {nil},      n = 1, expect = "" },
 
     -- %batt / %batt_icon: isCharged must reach the symbol function. #348.

--- a/token_semantics.lua
+++ b/token_semantics.lua
@@ -117,11 +117,15 @@ function Semantics.mem(total, available)
     return math.floor((total - available) / total * 100) .. "%"
 end
 
---- %sysused - system memory in use in MiB, rounded. Takes BYTES USED (not a
---- total/available pair) so no caller has to agree with another about units.
+--- %sysused - system memory in use in MiB, rounded, with the short "M" suffix.
+--- Same call as %ram above: bookshelf printed " MiB", bookends' compact form
+--- wins because its users' layouts are sized for it (#348). %sysused arrived
+--- from bookshelf after that sweep and kept the long suffix by oversight.
+--- Takes BYTES USED (not a total/available pair) so no caller has to agree
+--- with another about units.
 function Semantics.sysused(used_bytes)
     if not used_bytes then return "" end
-    return math.floor(used_bytes / 1024 / 1024 + 0.5) .. " MiB"
+    return math.floor(used_bytes / 1024 / 1024 + 0.5) .. "M"
 end
 
 --- %batt - battery capacity with a "%" suffix.

--- a/token_semantics.lua
+++ b/token_semantics.lua
@@ -121,7 +121,7 @@ end
 --- total/available pair) so no caller has to agree with another about units.
 function Semantics.sysused(used_bytes)
     if not used_bytes then return "" end
-    return math.floor(used_bytes / 1024 / 1024 + 0.5) .. " MiB"
+    return math.floor(used_bytes / 1024 / 1024 + 0.5) .. "M"
 end
 
 --- %batt - battery capacity with a "%" suffix.

--- a/token_semantics.lua
+++ b/token_semantics.lua
@@ -121,7 +121,7 @@ end
 --- total/available pair) so no caller has to agree with another about units.
 function Semantics.sysused(used_bytes)
     if not used_bytes then return "" end
-    return math.floor(used_bytes / 1024 / 1024 + 0.5) .. "M"
+    return math.floor(used_bytes / 1024 / 1024 + 0.5) .. " MiB"
 end
 
 --- %batt - battery capacity with a "%" suffix.


### PR DESCRIPTION
## What

Add MB-valued %sysused and %sysfree tokens (in addition to existing %mem) that
show free/used RAM as a concrete number ending in M, so the status bar is
readable on small screens like the KPW3.

## Bug

On kernels older than Linux 3.14 (e.g. KPW3 on Linux 2.6.x) `/proc/meminfo`
does not contain a `MemAvailable` line. The upstream code fell back to
`MemFree` only, which reports a value far lower than what the system actually
has available for KOReader. On a 512 MiB KPW3 the value jumped to ~493 M as
soon as a book opened, because nearly all of the ~500 MiB total was cached by
the kernel for file I/O — but that cache is reclaimable and available to the
app.

## Fix

- Parse `MemFree`, `Buffers` and `Cached` lines from `/proc/meminfo`.
- Build a fallback: `available = memfree + buffers + cached` (mirrors KOReader's
  `util.calcFreeMem` semantics).
- Compute `sysused` / `sysfree` via the same formula as before, but now the
  denominator is accurate.
- Strip the trailing unit to plain `M` (was ` MiB`) to save a couple
  characters in the tiny status bar.

## Testing

Verified on KPW3 (Linux 2.6.x, 512 MiB RAM):

| State | Before (MemFree only) | After (MemFree+Buffers+Cached) |
|---|---|---|
| Idle   | 367 M | 147 M |
| Book open | 493 M | 186 M |

Both values are now in the expected range for a 512 MiB device.

Also checked that on newer kernels (which have `MemAvailable`) the behavior
is unchanged — the fallback is only used when `MemAvailable` is absent.